### PR TITLE
[FEATURE] Provide configuration for garbage collection via scheduler

### DIFF
--- a/Classes/Configuration/Extension.php
+++ b/Classes/Configuration/Extension.php
@@ -24,9 +24,11 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Configuration;
 
 use EliasHaeussler\Typo3FormConsent\Controller\ConsentController;
+use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Form\Element\ConsentDataElement;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+use TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask;
 
 /**
  * Extension
@@ -85,5 +87,21 @@ final class Extension
         );
 
         Icon::registerForPluginIdentifier('Consent');
+    }
+
+    /**
+     * Register garbage collection task for consent table.
+     *
+     * FOR USE IN ext_localconf.php ONLY.
+     */
+    public static function registerGarbageCollectionTask(): void
+    {
+        if (!ExtensionManagementUtility::isLoaded('scheduler')) {
+            return;
+        }
+
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][TableGarbageCollectionTask::class]['options']['tables'][Consent::TABLE_NAME] = [
+            'expireField' => 'valid_until',
+        ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,12 @@
 		"typo3/cms-filelist": "^10.4 || 11.*.*@dev",
 		"typo3/cms-install": "^10.4 || 11.*.*@dev",
 		"typo3/cms-lowlevel": "^10.4 || 11.*.*@dev",
+		"typo3/cms-scheduler": "^10.4 || 11.*.*@dev",
 		"typo3/coding-standards": "^0.3.0",
 		"typo3/testing-framework": "^6.11"
+	},
+	"suggest": {
+		"typo3/cms-scheduler": "Allows garbage collection of expired consents (^10.4 || 11.*.*@dev)"
 	},
 	"config": {
 		"bin-dir": ".Build/bin",

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -24,3 +24,4 @@ defined('TYPO3') or die();
 \EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerFormEngineNode();
 \EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerPageTsConfig();
 \EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerPlugin();
+\EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerGarbageCollectionTask();


### PR DESCRIPTION
This PR adds a configuration for the scheduler garbage collection task. It deletes expired consents.