### PR TITLE
[FEATURE] Allow overriding template paths via finisher options

### DIFF
--- a/Classes/Domain/Finishers/ConsentFinisher.php
+++ b/Classes/Domain/Finishers/ConsentFinisher.php
@@ -370,8 +370,17 @@ class ConsentFinisher extends AbstractFinisher implements LoggerAwareInterface
     protected function initializeMail(): FluidEmail
     {
         $defaultTemplateConfiguration = $GLOBALS['TYPO3_CONF_VARS']['MAIL'];
-        $templateConfiguration = $this->configuration['view'] ?? null;
-        $mergedTemplateConfiguration = array_replace_recursive($defaultTemplateConfiguration, $templateConfiguration);
+        $typoScriptTemplateConfiguration = $this->configuration['view'] ?? [];
+        $finisherTemplateConfiguration = [
+            'templateRootPaths' => $this->options['templateRootPaths'] ?? [],
+            'partialRootPaths' => $this->options['partialRootPaths'] ?? [],
+            'layoutRootPaths' => $this->options['layoutRootPaths'] ?? [],
+        ];
+        $mergedTemplateConfiguration = array_replace_recursive(
+            $defaultTemplateConfiguration,
+            $typoScriptTemplateConfiguration,
+            $finisherTemplateConfiguration
+        );
         $templatePaths = GeneralUtility::makeInstance(TemplatePaths::class, $mergedTemplateConfiguration);
 
         $mail = GeneralUtility::makeInstance(FluidEmail::class, $templatePaths)

--- a/Configuration/Yaml/FinisherSetup.yaml
+++ b/Configuration/Yaml/FinisherSetup.yaml
@@ -16,3 +16,6 @@ TYPO3:
                 showDismissLink: false
                 confirmationPid: ''
                 storagePid: ''
+                templateRootPaths: { }
+                partialRootPaths: { }
+                layoutRootPaths: { }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ The following options are available to the `Consent` finisher:
 | **`showDismissLink`** | Show dismiss link in consent mail | :x: | `false` |
 | **`confirmationPid`** | Confirmation page (contains plugin) | :white_check_mark: | – |
 | **`storagePid`** | Storage page | :x: | `plugin.tx_formconsent.persistence.storagePid` |
+| **`templateRootPaths`** | Additional paths to template root | :x: | – |
+| **`partialRootPaths`** | Additional paths to template partials | :x: | – |
+| **`layoutRootPaths`** | Additional paths to template layouts | :x: | – |
+
+**Note:** Template paths that are configured via form finisher
+options are only applied to the appropriate form. They are merged
+with the default template paths configured via TypoScript.
 
 ## :gem: Credits
 


### PR DESCRIPTION
This PR adds the possibility to override or extend template paths via form finisher options.

The template paths are resolved in the following order (from lowest to highest priority):

1. Default configuration from `$GLOBALS['TYPO3_CONF_VARS']['MAIL']`
1. TypoScript configuration from `plugin.tx_formconsent.view`
1. Form finisher configuration