### PR TITLE
[BUGFIX] Properly JSON-encode uploaded files

### DIFF
--- a/Classes/Domain/Finishers/ConsentFinisher.php
+++ b/Classes/Domain/Finishers/ConsentFinisher.php
@@ -41,8 +41,10 @@ use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Mail\FluidEmail;
 use TYPO3\CMS\Core\Mail\Mailer;
 use TYPO3\CMS\Core\Messaging\AbstractMessage;
+use TYPO3\CMS\Core\Resource\FileReference as CoreFileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference as ExtbaseFileReference;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
 use TYPO3\CMS\Fluid\View\TemplatePaths;
@@ -315,6 +317,17 @@ class ConsentFinisher extends AbstractFinisher implements LoggerAwareInterface
         // Remove honeypot field
         $honeypotIdentifier = $this->getHoneypotIdentifier();
         unset($formData[$honeypotIdentifier]);
+
+        foreach ($formData as $key => $value) {
+            if (is_object($value)) {
+                if ($value instanceof ExtbaseFileReference) {
+                    $value = $value->getOriginalResource();
+                }
+                if ($value instanceof CoreFileReference) {
+                    $formData[$key] = $value->getOriginalFile()->getUid();
+                }
+            }
+        }
 
         return $formData;
     }

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 		"typo3/cms-lowlevel": "^10.4 || ^11.5",
 		"typo3/cms-scheduler": "^10.4 || ^11.5",
 		"typo3/coding-standards": "^0.3.0",
-		"typo3/testing-framework": "^6.11.2"
+		"typo3/testing-framework": "^6.13"
 	},
 	"suggest": {
 		"typo3/cms-dashboard": "Adds a custom form consent widget to the TYPO3 dashboard (^10.4 || ^11.5)",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,5 +9,3 @@ parameters:
         - Classes
         - Configuration
         - Tests
-    ignoreErrors:
-        - '#^Property [a-zA-Z0-9\\_]+::\$coreExtensionsToLoad type has no value type specified in iterable type array\.$#'


### PR DESCRIPTION
This PR solves the problem that uploaded files could not be JSON-encoded. Instead of encoding the object, the file UID is now persisted.