### PR TITLE
[BUGFIX] Handle changed instantiation of FlashMessageFinisher

### DIFF
--- a/Classes/Domain/Finishers/ConsentFinisher.php
+++ b/Classes/Domain/Finishers/ConsentFinisher.php
@@ -186,6 +186,10 @@ class ConsentFinisher extends AbstractFinisher implements LoggerAwareInterface
     public function injectFlashMessageFinisher(FlashMessageFinisher $flashMessageFinisher): void
     {
         $this->flashMessageFinisher = $flashMessageFinisher;
+
+        if (method_exists($this->flashMessageFinisher, 'setFinisherIdentifier')) {
+            $this->flashMessageFinisher->setFinisherIdentifier('FlashMessage');
+        }
     }
 
     public function injectHashService(HashService $hashService): void


### PR DESCRIPTION
This PR fixes the initialization of the injected `FlashMessageFinisher` inside `ConsentFinisher`. The initialization of finishers extending `AbstractFinisher` changed with [#94317](https://forge.typo3.org/issues/94317) aka https://github.com/TYPO3/typo3/commit/962042cec5134816c961d92d90b59175274bc9e8.