### PR TITLE
[BUGFIX] Include translation files in FormEngine

### DIFF
--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -118,6 +118,8 @@ TYPO3:
                     confirmationPid: ''
                     storagePid: ''
               FormEngine:
+                translationFiles:
+                  1632317570: 'EXT:form_consent/Resources/Private/Language/locallang_form.xlf'
                 label: 'tt_content.finishersDefinition.Consent.label'
                 elements:
                   subject:


### PR DESCRIPTION
This PR

- [x] includes translation files in FormEngine
- [x] so that overridden finisher settings are labeled correctly