### PR TITLE
[BUGFIX] Avoid escaping of links in plain-text mails

### DIFF
--- a/Resources/Private/Partials/Link/Approve.txt
+++ b/Resources/Private/Partials/Link/Approve.txt
@@ -1,7 +1,7 @@
-<f:uri.action action="approve"
+<f:format.raw><f:uri.action action="approve"
               controller="Consent"
               extensionName="FormConsent"
               pluginName="Consent"
               absolute="1"
               arguments="{hash: consent.validationHash, email: consent.email}"
-              pageUid="{pageUid}" />
+              pageUid="{pageUid}" /></f:format.raw>

--- a/Resources/Private/Partials/Link/Dismiss.txt
+++ b/Resources/Private/Partials/Link/Dismiss.txt
@@ -1,7 +1,7 @@
-<f:uri.action action="dismiss"
+<f:format.raw><f:uri.action action="dismiss"
               controller="Consent"
               extensionName="FormConsent"
               pluginName="Consent"
               absolute="1"
               arguments="{hash: consent.validationHash, email: consent.email}"
-              pageUid="{pageUid}" />
+              pageUid="{pageUid}" /></f:format.raw>


### PR DESCRIPTION
This PR fixes an issue with links in plain-text mails. Prior to this change, all links were escaped, resulting in malicious URLs:

```diff
-/confirmation?tx_formconsent_consent[action]=approve&amp;tx_formconsent_consent[hash]=foo&amp;tx_formconsent_consent[email]=user@example.com
+/confirmation?tx_formconsent_consent[action]=approve&tx_formconsent_consent[hash]=foo&tx_formconsent_consent[email]=user@example.com
```

⚠️ If partials were overridden, this change must be applied manually.