### PR TITLE
[BUGFIX] Switch to arm-compatible Selenium image

### DIFF
--- a/.ddev/docker-compose.selenium.yaml
+++ b/.ddev/docker-compose.selenium.yaml
@@ -7,7 +7,7 @@ services:
       - selenium
   selenium:
     container_name: ddev-${DDEV_SITENAME}-selenium
-    image: selenium/standalone-chrome-debug:3.13.0-argon
+    image: seleniarm/standalone-chromium:4.1.2-20220227
     networks:
       default:
         aliases:


### PR DESCRIPTION
This PR exchanges the Selenium image used for acceptance tests.

```diff
-selenium/standalone-chrome-debug:3.13.0-argon
+seleniarm/standalone-chromium:4.1.2-20220227
```

The new image supports ARM as well, adding support for Apple M1 computers.

Related issue: SeleniumHQ/docker-selenium/issues/1076