### PR TITLE
[FEATURE] Allow passing custom responses via DismissConsentEvent

### DIFF
--- a/Classes/Controller/ConsentController.php
+++ b/Classes/Controller/ConsentController.php
@@ -108,6 +108,7 @@ final class ConsentController extends ActionController
 
     /**
      * @throws IllegalObjectTypeException
+     * @throws ImmediateResponseException
      * @throws UnknownObjectException
      */
     public function dismissAction(string $hash, string $email): ResponseInterface
@@ -147,7 +148,7 @@ final class ConsentController extends ActionController
         $this->consentRepository->remove($consent);
         $this->persistenceManager->persistAll();
 
-        return $this->createResponse();
+        return $this->createHtmlResponse($event->getResponse());
     }
 
     /**

--- a/Classes/Event/DismissConsentEvent.php
+++ b/Classes/Event/DismissConsentEvent.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Event;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * DismissConsentEvent
@@ -34,6 +35,7 @@ use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 final class DismissConsentEvent
 {
     private Consent $consent;
+    private ?ResponseInterface $response = null;
 
     public function __construct(Consent $consent)
     {
@@ -43,5 +45,16 @@ final class DismissConsentEvent
     public function getConsent(): Consent
     {
         return $this->consent;
+    }
+
+    public function getResponse(): ?ResponseInterface
+    {
+        return $this->response;
+    }
+
+    public function setResponse(?ResponseInterface $response): self
+    {
+        $this->response = $response;
+        return $this;
     }
 }

--- a/Tests/Unit/Event/DismissConsentEventTest.php
+++ b/Tests/Unit/Event/DismissConsentEventTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Event;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Event\DismissConsentEvent;
+use TYPO3\CMS\Core\Http\Response;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -53,5 +54,17 @@ final class DismissConsentEventTest extends UnitTestCase
     {
         $expected = $this->consent;
         self::assertSame($expected, $this->subject->getConsent());
+    }
+
+    /**
+     * @test
+     */
+    public function getResponseReturnsResponse(): void
+    {
+        self::assertNull($this->subject->getResponse());
+
+        $response = new Response();
+
+        self::assertSame($response, $this->subject->setResponse($response)->getResponse());
     }
 }


### PR DESCRIPTION
This PR streamlines the possibilities of `ApproveConsentEvent` and `DismissConsentEvent`. Both events are now able to receive custom responses that are evaluated in the dispatching `ConsentController`.

This is a follow-up to #24.