### PR TITLE
[BUGFIX] Skip one acceptance test for PHP 8.1

### DIFF
--- a/Tests/Acceptance/Backend/ConsentDataElementCest.php
+++ b/Tests/Acceptance/Backend/ConsentDataElementCest.php
@@ -36,6 +36,11 @@ final class ConsentDataElementCest
 {
     public function canSeeConsentInBackendListModule(AcceptanceTester $I, Backend $backend): void
     {
+        // @todo Remove once https://github.com/symfony/symfony/pull/45925 is released
+        if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
+            $I->markTestSkipped('Skipped until https://github.com/symfony/symfony/pull/45925 is released.');
+        }
+
         $I->amOnPage('/');
         $I->fillAndSubmitForm();
 


### PR DESCRIPTION
A Backend acceptance test is skipped as it is not compatible with the current version of symfony/rate-limiter.

Related: symfony/symfony#45925