### PR TITLE
[TASK] Streamline locallang*.xlf files with XLIFF 1.2

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,80 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.0">
-	<file source-language="en">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:form_consent/Resources/Private/Language/locallang.xlf" date="2022-04-21T20:43:12Z" product-name="form_consent">
 		<header/>
 		<body>
-			<trans-unit id="consentMail.subject">
+			<trans-unit id="consentMail.subject" resname="consentMail.subject">
 				<source>Approve your consent</source>
 			</trans-unit>
-			<trans-unit id="consentMail.title">
+			<trans-unit id="consentMail.title" resname="consentMail.title">
 				<source>Please approve your consent</source>
 			</trans-unit>
-			<trans-unit id="consentMail.salutation">
+			<trans-unit id="consentMail.salutation" resname="consentMail.salutation">
 				<source>Hello %s</source>
 			</trans-unit>
-			<trans-unit id="consentMail.body.approve">
+			<trans-unit id="consentMail.body.approve" resname="consentMail.body.approve">
 				<source>your consent was registered successfully. Please click the following link to approve it:</source>
 			</trans-unit>
-			<trans-unit id="consentMail.body.dismiss">
+			<trans-unit id="consentMail.body.dismiss" resname="consentMail.body.dismiss">
 				<source>If you feel this consent was given by accident or if you want to dismiss it, please click the following link:</source>
 			</trans-unit>
-			<trans-unit id="consentMail.error">
+			<trans-unit id="consentMail.error" resname="consentMail.error">
 				<source>The consent mail could not be sent.</source>
 			</trans-unit>
 
-			<trans-unit id="consent.approve.error.invalidConsent.title">
+			<trans-unit id="consent.approve.error.invalidConsent.title" resname="consent.approve.error.invalidConsent.title">
 				<source>Invalid link</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.error.invalidConsent.body">
+			<trans-unit id="consent.approve.error.invalidConsent.body" resname="consent.approve.error.invalidConsent.body">
 				<source>The link you clicked is no longer valid or has already been clicked. Please fill out the form again.</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.error.invalidEmail.title">
+			<trans-unit id="consent.approve.error.invalidEmail.title" resname="consent.approve.error.invalidEmail.title">
 				<source>Invalid email address</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.error.invalidEmail.body">
+			<trans-unit id="consent.approve.error.invalidEmail.body" resname="consent.approve.error.invalidEmail.body">
 				<source>The email address sent with the link is not valid. Please fill out the form again.</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.error.alreadyApproved.title">
+			<trans-unit id="consent.approve.error.alreadyApproved.title" resname="consent.approve.error.alreadyApproved.title">
 				<source>Consent already given</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.error.alreadyApproved.body">
+			<trans-unit id="consent.approve.error.alreadyApproved.body" resname="consent.approve.error.alreadyApproved.body">
 				<source>The link you clicked has already been clicked. This means that consent has already been given and the link is no longer valid.</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.error.unknown.title">
+			<trans-unit id="consent.approve.error.unknown.title" resname="consent.approve.error.unknown.title">
 				<source>Unknown error</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.error.unknown.body">
+			<trans-unit id="consent.approve.error.unknown.body" resname="consent.approve.error.unknown.body">
 				<source>An unknown error has occurred. Please try clicking the link from the email again. If the problem persists, please fill out the form again.</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.success.title">
+			<trans-unit id="consent.approve.success.title" resname="consent.approve.success.title">
 				<source>Consent successful</source>
 			</trans-unit>
-			<trans-unit id="consent.approve.success.body">
+			<trans-unit id="consent.approve.success.body" resname="consent.approve.success.body">
 				<source>Thank you, your approval was successful. You can now delete the email.</source>
 			</trans-unit>
 
-			<trans-unit id="consent.dismiss.error.invalidConsent.title">
+			<trans-unit id="consent.dismiss.error.invalidConsent.title" resname="consent.dismiss.error.invalidConsent.title">
 				<source>Invalid link</source>
 			</trans-unit>
-			<trans-unit id="consent.dismiss.error.invalidConsent.body">
+			<trans-unit id="consent.dismiss.error.invalidConsent.body" resname="consent.dismiss.error.invalidConsent.body">
 				<source>The link you clicked is no longer valid or has already been clicked.</source>
 			</trans-unit>
-			<trans-unit id="consent.dismiss.error.invalidEmail.title">
+			<trans-unit id="consent.dismiss.error.invalidEmail.title" resname="consent.dismiss.error.invalidEmail.title">
 				<source>Invalid email address</source>
 			</trans-unit>
-			<trans-unit id="consent.dismiss.error.invalidEmail.body">
+			<trans-unit id="consent.dismiss.error.invalidEmail.body" resname="consent.dismiss.error.invalidEmail.body">
 				<source>The email address sent with the link is not valid. Please fill out the form again.</source>
 			</trans-unit>
-			<trans-unit id="consent.dismiss.error.unknown.title">
+			<trans-unit id="consent.dismiss.error.unknown.title" resname="consent.dismiss.error.unknown.title">
 				<source>Unknown error</source>
 			</trans-unit>
-			<trans-unit id="consent.dismiss.error.unknown.body">
+			<trans-unit id="consent.dismiss.error.unknown.body" resname="consent.dismiss.error.unknown.body">
 				<source>An unknown error has occurred. Please try clicking the link from the email again. If the problem persists, please fill out the form again.</source>
 			</trans-unit>
-			<trans-unit id="consent.dismiss.success.title">
+			<trans-unit id="consent.dismiss.success.title" resname="consent.dismiss.success.title">
 				<source>Consent successfully revoked</source>
 			</trans-unit>
-			<trans-unit id="consent.dismiss.success.body">
+			<trans-unit id="consent.dismiss.success.body" resname="consent.dismiss.success.body">
 				<source>You have successfully revoked your consent. You can now delete the email.</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.0">
-	<file source-language="en">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:form_consent/Resources/Private/Language/locallang_be.xlf" date="2022-04-21T20:43:12Z" product-name="form_consent">
 		<header/>
 		<body>
-			<trans-unit id="form.message.newRecord">
+			<trans-unit id="form.message.newRecord" resname="form.message.newRecord">
 				<source>No data submitted yet.</source>
 			</trans-unit>
-			<trans-unit id="form.message.noDataAvailable">
+			<trans-unit id="form.message.noDataAvailable" resname="form.message.noDataAvailable">
 				<source>No form data was submitted.</source>
 			</trans-unit>
 
-			<trans-unit id="form.data.header">
+			<trans-unit id="form.data.header" resname="form.data.header">
 				<source>Submitted form data</source>
 			</trans-unit>
 
-			<trans-unit id="widgets.approvedConsents.header">
+			<trans-unit id="widgets.approvedConsents.header" resname="widgets.approvedConsents.header">
 				<source>Form consent</source>
 			</trans-unit>
-			<trans-unit id="widgets.approvedConsents.body">
+			<trans-unit id="widgets.approvedConsents.body" resname="widgets.approvedConsents.body">
 				<source>An overview about all approved consents</source>
 			</trans-unit>
 
-			<trans-unit id="charts.approved">
+			<trans-unit id="charts.approved" resname="charts.approved">
 				<source>approved</source>
 			</trans-unit>
-			<trans-unit id="charts.nonApproved">
+			<trans-unit id="charts.nonApproved" resname="charts.nonApproved">
 				<source>non-approved</source>
 			</trans-unit>
-			<trans-unit id="charts.dismissed">
+			<trans-unit id="charts.dismissed" resname="charts.dismissed">
 				<source>dismissed</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -1,62 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.0">
-	<file source-language="en">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:form_consent/Resources/Private/Language/locallang_db.xlf" date="2022-04-21T20:43:12Z" product-name="form_consent">
 		<header/>
 		<body>
-			<trans-unit id="tabs.consent">
+			<trans-unit id="tabs.consent" resname="tabs.consent">
 				<source>Consent</source>
 			</trans-unit>
 
-			<trans-unit id="plugins.consent">
+			<trans-unit id="plugins.consent" resname="plugins.consent">
 				<source>Form consent</source>
 			</trans-unit>
-			<trans-unit id="plugins.consent.header">
+			<trans-unit id="plugins.consent.header" resname="plugins.consent.header">
 				<source>Form consent</source>
 			</trans-unit>
-			<trans-unit id="plugins.consent.body">
+			<trans-unit id="plugins.consent.body" resname="plugins.consent.body">
 				<source>Inserts a plugin which allows approval and dismiss of form consents.</source>
 			</trans-unit>
 
-			<trans-unit id="tx_formconsent_domain_model_consent">
+			<trans-unit id="tx_formconsent_domain_model_consent" resname="tx_formconsent_domain_model_consent">
 				<source>Consent</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.email">
+			<trans-unit id="tx_formconsent_domain_model_consent.email" resname="tx_formconsent_domain_model_consent.email">
 				<source>E-mail address</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.date">
+			<trans-unit id="tx_formconsent_domain_model_consent.date" resname="tx_formconsent_domain_model_consent.date">
 				<source>Submit date</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.data">
+			<trans-unit id="tx_formconsent_domain_model_consent.data" resname="tx_formconsent_domain_model_consent.data">
 				<source>Form data</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.form_persistence_identifier">
+			<trans-unit id="tx_formconsent_domain_model_consent.form_persistence_identifier" resname="tx_formconsent_domain_model_consent.form_persistence_identifier">
 				<source>Form location</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.original_request_parameters">
+			<trans-unit id="tx_formconsent_domain_model_consent.original_request_parameters" resname="tx_formconsent_domain_model_consent.original_request_parameters">
 				<source>Original request parameters</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.original_content_element_uid">
+			<trans-unit id="tx_formconsent_domain_model_consent.original_content_element_uid" resname="tx_formconsent_domain_model_consent.original_content_element_uid">
 				<source>Content element</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.state">
+			<trans-unit id="tx_formconsent_domain_model_consent.state" resname="tx_formconsent_domain_model_consent.state">
 				<source>State</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.state.new">
+			<trans-unit id="tx_formconsent_domain_model_consent.state.new" resname="tx_formconsent_domain_model_consent.state.new">
 				<source>New</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.state.approved">
+			<trans-unit id="tx_formconsent_domain_model_consent.state.approved" resname="tx_formconsent_domain_model_consent.state.approved">
 				<source>Approved</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.state.dismissed">
+			<trans-unit id="tx_formconsent_domain_model_consent.state.dismissed" resname="tx_formconsent_domain_model_consent.state.dismissed">
 				<source>Dismissed</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.update_date">
+			<trans-unit id="tx_formconsent_domain_model_consent.update_date" resname="tx_formconsent_domain_model_consent.update_date">
 				<source>Date of last state change</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.valid_until">
+			<trans-unit id="tx_formconsent_domain_model_consent.valid_until" resname="tx_formconsent_domain_model_consent.valid_until">
 				<source>Valid until</source>
 			</trans-unit>
-			<trans-unit id="tx_formconsent_domain_model_consent.validation_hash">
+			<trans-unit id="tx_formconsent_domain_model_consent.validation_hash" resname="tx_formconsent_domain_model_consent.validation_hash">
 				<source>Validation hash</source>
 			</trans-unit>
 		</body>

--- a/Resources/Private/Language/locallang_form.xlf
+++ b/Resources/Private/Language/locallang_form.xlf
@@ -1,112 +1,112 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.0">
-	<file source-language="en">
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file source-language="en" datatype="plaintext" original="EXT:form_consent/Resources/Private/Language/locallang_form.xlf" date="2022-04-21T20:43:12Z" product-name="form_consent">
 		<header/>
 		<body>
-			<trans-unit id="formEditor.elements.Form.editor.finishers.Consent.label">
+			<trans-unit id="formEditor.elements.Form.editor.finishers.Consent.label" resname="formEditor.elements.Form.editor.finishers.Consent.label">
 				<source>Consent</source>
 			</trans-unit>
 
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.default.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.default.label" resname="formEditor.elements.Form.finishers.Consent.editor.default.label">
 				<source>Consent</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.subject.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.subject.label" resname="formEditor.elements.Form.finishers.Consent.editor.subject.label">
 				<source>Subject</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.recipientAddress.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.recipientAddress.label" resname="formEditor.elements.Form.finishers.Consent.editor.recipientAddress.label">
 				<source>Recipient e-mail address</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.recipientName.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.recipientName.label" resname="formEditor.elements.Form.finishers.Consent.editor.recipientName.label">
 				<source>Recipient name</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.senderAddress.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.senderAddress.label" resname="formEditor.elements.Form.finishers.Consent.editor.senderAddress.label">
 				<source>Sender e-mail address</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.senderName.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.senderName.label" resname="formEditor.elements.Form.finishers.Consent.editor.senderName.label">
 				<source>Sender name</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.approvalPeriod.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.approvalPeriod.label" resname="formEditor.elements.Form.finishers.Consent.editor.approvalPeriod.label">
 				<source>Approval period</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.approvalPeriod.fieldExplanationText">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.approvalPeriod.fieldExplanationText" resname="formEditor.elements.Form.finishers.Consent.editor.approvalPeriod.fieldExplanationText">
 				<source>Time period in seconds where consent can be given. Set this value to "0" to allow unlimited approval.</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.showDismissLink.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.showDismissLink.label" resname="formEditor.elements.Form.finishers.Consent.editor.showDismissLink.label">
 				<source>Show dismiss link</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.showDismissLink.fieldExplanationText">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.showDismissLink.fieldExplanationText" resname="formEditor.elements.Form.finishers.Consent.editor.showDismissLink.fieldExplanationText">
 				<source>Enable this checkbox if users should be able to dismiss their consent.</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.confirmationPid.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.confirmationPid.label" resname="formEditor.elements.Form.finishers.Consent.editor.confirmationPid.label">
 				<source>Confirmation page</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.confirmationPid.buttonLabel">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.confirmationPid.buttonLabel" resname="formEditor.elements.Form.finishers.Consent.editor.confirmationPid.buttonLabel">
 				<source>Page</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.storagePid.label">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.storagePid.label" resname="formEditor.elements.Form.finishers.Consent.editor.storagePid.label">
 				<source>Storage page</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.storagePid.buttonLabel">
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.storagePid.buttonLabel" resname="formEditor.elements.Form.finishers.Consent.editor.storagePid.buttonLabel">
 				<source>Page</source>
 			</trans-unit>
 
-			<trans-unit id="formEditor.elements.Form.finisher.Consent.editor.header.label">
+			<trans-unit id="formEditor.elements.Form.finisher.Consent.editor.header.label" resname="formEditor.elements.Form.finisher.Consent.editor.header.label">
 				<source>Consent</source>
 			</trans-unit>
 
-			<trans-unit id="tt_content.finishersDefinition.Consent.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.label" resname="tt_content.finishersDefinition.Consent.label">
 				<source>Consent</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.subject.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.subject.label" resname="tt_content.finishersDefinition.Consent.subject.label">
 				<source>Subject</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.recipientAddress.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.recipientAddress.label" resname="tt_content.finishersDefinition.Consent.recipientAddress.label">
 				<source>Recipient e-mail address</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.recipientName.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.recipientName.label" resname="tt_content.finishersDefinition.Consent.recipientName.label">
 				<source>Recipient name</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.senderAddress.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.senderAddress.label" resname="tt_content.finishersDefinition.Consent.senderAddress.label">
 				<source>Sender e-mail address</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.senderName.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.senderName.label" resname="tt_content.finishersDefinition.Consent.senderName.label">
 				<source>Sender name</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.approvalPeriod.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.approvalPeriod.label" resname="tt_content.finishersDefinition.Consent.approvalPeriod.label">
 				<source>Approval period</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.showDismissLink.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.showDismissLink.label" resname="tt_content.finishersDefinition.Consent.showDismissLink.label">
 				<source>Show dismiss link</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.confirmationPid.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.confirmationPid.label" resname="tt_content.finishersDefinition.Consent.confirmationPid.label">
 				<source>Confirmation page</source>
 			</trans-unit>
-			<trans-unit id="tt_content.finishersDefinition.Consent.storagePid.label">
+			<trans-unit id="tt_content.finishersDefinition.Consent.storagePid.label" resname="tt_content.finishersDefinition.Consent.storagePid.label">
 				<source>Storage page</source>
 			</trans-unit>
 
-			<trans-unit id="validation.recipientAddress.empty">
+			<trans-unit id="validation.recipientAddress.empty" resname="validation.recipientAddress.empty">
 				<source>The finisher option "recipientAddress" must be set.</source>
 			</trans-unit>
-			<trans-unit id="validation.recipientAddress.invalid">
+			<trans-unit id="validation.recipientAddress.invalid" resname="validation.recipientAddress.invalid">
 				<source>The finisher option "recipientAddress" must contain a valid e-mail address.</source>
 			</trans-unit>
-			<trans-unit id="validation.senderAddress.invalid">
+			<trans-unit id="validation.senderAddress.invalid" resname="validation.senderAddress.invalid">
 				<source>The finisher option "senderAddress" must contain a valid e-mail address.</source>
 			</trans-unit>
-			<trans-unit id="validation.approvalPeriod.invalid">
+			<trans-unit id="validation.approvalPeriod.invalid" resname="validation.approvalPeriod.invalid">
 				<source>The finisher option "approvalPeriod" must be zero or more seconds.</source>
 			</trans-unit>
-			<trans-unit id="validation.confirmationPid.empty">
+			<trans-unit id="validation.confirmationPid.empty" resname="validation.confirmationPid.empty">
 				<source>The finisher option "confirmationPid" must be set.</source>
 			</trans-unit>
-			<trans-unit id="validation.confirmationPid.invalid">
+			<trans-unit id="validation.confirmationPid.invalid" resname="validation.confirmationPid.invalid">
 				<source>The finisher option "confirmationPid" must be set to a valid page.</source>
 			</trans-unit>
-			<trans-unit id="validation.storagePid.empty">
+			<trans-unit id="validation.storagePid.empty" resname="validation.storagePid.empty">
 				<source>The finisher option "storagePid" must be set.</source>
 			</trans-unit>
-			<trans-unit id="validation.storagePid.invalid">
+			<trans-unit id="validation.storagePid.invalid" resname="validation.storagePid.invalid">
 				<source>The finisher option "storagePid" must be set to a valid page.</source>
 			</trans-unit>
 		</body>


### PR DESCRIPTION
This PR streamlines all locallang*.xlf files with the XLIFF 1.2 standard, which is currently supported by TYPO3 CMS.