### PR TITLE
[BUGFIX] Automate local development environment preparation

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -15,8 +15,8 @@ nfs_mount_enabled: false
 mutagen_enabled: false
 hooks:
   post-start:
-  - composer: environment:prepare
-  - exec-host: ddev import-files --src Tests/Acceptance/Data/Fileadmin
+  - composer: prepare-environment
+  - composer: import-fixtures
 omit_containers: [dba]
 use_dns_when_possible: true
 composer_version: "2"

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -24,7 +24,10 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        run: composer require --no-progress --no-plugins typo3/cms-dashboard:"~10.4.11 || ~11.5.1" typo3/cms-scheduler:"~10.4.11 || ~11.5.1"
+        run: |
+          composer require --no-progress --no-plugins \
+            typo3/cms-dashboard:"~10.4.11 || ~11.5.1" \
+            typo3/cms-scheduler:"~10.4.11 || ~11.5.1"
 
       # Check Composer dependencies
       - name: Check dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing
+
+This project uses [DDEV][1] for local development. Make sure to set it up as
+described below. For continuous integration, we use GitHub Actions.
+
+## Preparation
+
+```bash
+# Clone repository
+git clone https://github.com/eliashaeussler/typo3-form-consent.git
+cd typo3-form-consent
+
+# Start DDEV project
+ddev start
+```
+
+You can access the DDEV site at <https://typo3-ext-form-consent.ddev.site/>.
+
+## Fixtures
+
+File fixtures and database fixtures are automatically imported on each `ddev start`.
+You can also manually import fixtures by running:
+
+```bash
+ddev composer import-fixtures
+```
+
+:bulb: You can access the TYPO3 backend using the `admin` / `password` credentials.
+
+## Run linters
+
+```bash
+# All linters
+ddev composer lint
+
+# Specific linters
+ddev composer lint:composer
+ddev composer lint:editorconfig
+ddev composer lint:php
+ddev composer lint:typoscript
+
+# All static code analyzers
+ddev composer sca
+
+# Specific static code analyzers
+ddev composer sca:php
+```
+
+## Run tests
+
+```bash
+# All tests
+ddev composer test
+
+# Specific tests
+ddev composer test:acceptance
+ddev composer test:functional
+ddev composer test:unit
+
+# Enable Xdebug to collect code coverage
+ddev xdebug on
+
+# All tests with code coverage
+ddev composer test:ci
+
+# Specific tests with code coverage
+ddev composer test:ci:acceptance
+ddev composer test:ci:functional
+ddev composer test:ci:unit
+
+# Merge code coverage of all test suites
+ddev composer test:ci:merge
+```
+
+:bulb: Xdebug inside DDEV is configured to run in `coverage` mode only. If you
+need additional debug support, you can temporarily change the appropriate web
+environment `XDEBUG_MODE` variable in [`.ddev/config.yaml`][2].
+
+### Test reports
+
+Code coverage reports are written to `.Build/log/coverage`. You can open the
+last merged HTML report like follows:
+
+```bash
+open .Build/log/coverage/html/_merged/index.html
+```
+
+:bulb: Make sure to merge coverage reports as written above.
+
+Reports of acceptance tests are written to `.Build/log/acceptance-reports`. You
+can open the last HTML report like follows:
+
+```bash
+open .Build/log/acceptance-reports/records.html
+```
+
+## Submit a pull request
+
+Once you have finished your work, please **submit a pull request** and describe
+what you've done. Ideally, your PR references an issue describing the problem
+you're trying to solve.
+
+All described code quality tools are automatically executed on each pull request
+for all currently supported PHP versions and TYPO3 versions. Take a look at the
+appropriate [workflows][2] to get a detailed overview.
+
+[1]: https://ddev.readthedocs.io/en/stable/
+[2]: .ddev/config.yaml
+[3]: .github/workflows

--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ Form values are now represented as an instance of [`JsonType`][2].
   - If you still need to extend or override them, consider refactoring
     your code or [submit an issue][3].
 
+## :technologist: Contributing
+
+Please have a look at [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 ## :gem: Credits
 
 Icons made by [Google](https://www.flaticon.com/authors/google) from

--- a/codeception.yml
+++ b/codeception.yml
@@ -18,13 +18,6 @@ suites:
             dsn: 'mysql:host=db;dbname=db'
             user: 'root'
             password: 'root'
-            dump:
-              - Tests/Acceptance/Data/Fixtures/be_users.sql
-              - Tests/Acceptance/Data/Fixtures/pages.sql
-              - Tests/Acceptance/Data/Fixtures/sys_file.sql
-              - Tests/Acceptance/Data/Fixtures/sys_template.sql
-              - Tests/Acceptance/Data/Fixtures/tt_content.sql
-              - Tests/Acceptance/Data/Fixtures/tx_formconsent_domain_model_consent.sql
             populate: true
             waitlock: 5
         - MailHog:

--- a/composer.json
+++ b/composer.json
@@ -98,24 +98,22 @@
 	},
 	"scripts": {
 		"post-autoload-dump": [
-			"@environment:prepare",
+			"@prepare-environment",
 			"codecept build"
 		],
-		"environment:prepare": [
-			"@environment:prepare:extension",
-			"@environment:prepare:sites-config",
-			"@environment:prepare:additional-config"
+		"import-fixtures": [
+			"@import-fixtures:files",
+			"@import-fixtures:db"
 		],
-		"environment:prepare:additional-config": [
-			"[ -L .Build/web/typo3conf/AdditionalConfiguration.php ] || ln -snvf ../../../Tests/Build/AdditionalConfiguration.php .Build/web/typo3conf/AdditionalConfiguration.php"
+		"import-fixtures:db": [
+			"mysql -Nse 'show tables' db | while read table; do mysql -e \"truncate table $table\" db; done",
+			"typo3cms install:setup --no-interaction --force",
+			"for file in Tests/Acceptance/Data/Fixtures/*.sql; do mysql db < $file; done"
 		],
-		"environment:prepare:extension": [
-			"mkdir -p .Build/web/typo3conf/ext/",
-			"[ -L .Build/web/typo3conf/ext/form_consent ] || ln -snvf ../../../../. .Build/web/typo3conf/ext/form_consent"
-		],
-		"environment:prepare:sites-config": [
-			"mkdir -p config/sites/main",
-			"[ -L config/sites/main/config.yaml ] || ln -snvf ../../../Tests/Build/sites-config.yaml config/sites/main/config.yaml"
+		"import-fixtures:files": [
+			"mkdir -p .Build/web",
+			"rm -rf .Build/web/fileadmin",
+			"cp -r Tests/Acceptance/Data/Fileadmin .Build/web/fileadmin"
 		],
 		"lint": [
 			"@lint:composer",
@@ -127,6 +125,19 @@
 		"lint:editorconfig": "ec --fix -e .Build",
 		"lint:php": "php-cs-fixer fix",
 		"lint:typoscript": "typoscript-lint -c typoscript-lint.yml",
+		"prepare-environment": [
+			"@prepare-environment:extension",
+			"@prepare-environment:config"
+		],
+		"prepare-environment:config": [
+			"mkdir -p config/sites/main",
+			"[ -L config/sites/main/config.yaml ] || ln -snvf ../../../Tests/Build/sites-config.yaml config/sites/main/config.yaml",
+			"[ -L .Build/web/typo3conf/AdditionalConfiguration.php ] || ln -snvf ../../../Tests/Build/AdditionalConfiguration.php .Build/web/typo3conf/AdditionalConfiguration.php"
+		],
+		"prepare-environment:extension": [
+			"mkdir -p .Build/web/typo3conf/ext/",
+			"[ -L .Build/web/typo3conf/ext/form_consent ] || ln -snvf ../../../../. .Build/web/typo3conf/ext/form_consent"
+		],
 		"sca": [
 			"@sca:php"
 		],
@@ -140,10 +151,7 @@
 			"@test:acceptance:prepare",
 			"@test:acceptance:run"
 		],
-		"test:acceptance:prepare": [
-			"mysql -Nse 'show tables' db | while read table; do mysql -e \"truncate table $table\" db; done",
-			"typo3cms install:setup --no-interaction --force"
-		],
+		"test:acceptance:prepare": "@import-fixtures",
 		"test:acceptance:run": "codecept run",
 		"test:ci": [
 			"@test:ci:acceptance",


### PR DESCRIPTION
This PR streamlines and automates local development environment preparation. It is now executed on each `ddev start`, `composer install` and `composer update`. This includes:

- [x] Fileadmin fixtures
- [x] DB fixtures
- [x] TYPO3 setup
- [x] TYPO3 config