### PR TITLE
[BUGFIX] Avoid concurrent workflow runs in pull requests

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -1,5 +1,12 @@
 name: CGL
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   cgl:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,12 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   tests:


### PR DESCRIPTION
This PR limits workflow runs to the `main` and `develop` branches when triggered via `push` event. This avoids concurrent workflow runs if an active pull request exists.