### PR TITLE
[FEATURE] Populate last inserted consent with finisher variable provider

### DIFF
--- a/Classes/Domain/Finishers/ConsentFinisher.php
+++ b/Classes/Domain/Finishers/ConsentFinisher.php
@@ -114,6 +114,13 @@ final class ConsentFinisher extends AbstractFinisher implements LoggerAwareInter
         $this->persistenceManager->add($consent);
         $this->persistenceManager->persistAll();
 
+        // Add consent to finisher context
+        $this->finisherContext->getFinisherVariableProvider()->add(
+            $this->shortFinisherIdentifier,
+            'lastInsertedConsent',
+            $consent
+        );
+
         // Build mail
         $mail = $this->initializeMail($finisherOptions);
         $mail->assign('consent', $consent);

--- a/README.md
+++ b/README.md
@@ -51,9 +51,31 @@ Alternatively, you can download the extension via the
 
 ## :zap: Usage
 
+### Finisher
+
 A new finisher `Consent` is available in the backend form editor.
 It saves all submitted form data in the database and sends a
 corresponding mail to either approve or dismiss a given consent.
+
+The last inserted consent is populated with the finisher variable
+provider. It can be accessed as `{Consent.lastInsertedConsent}` in
+the `.form.yaml` configuration.
+
+Example:
+
+```yaml
+finishers:
+  -
+    options:
+      table: tx_myextension_domain_model_mymodel
+      mode: insert
+      databaseColumnMappings:
+        consent:
+          value: '{Consent.lastInsertedConsent.uid}'
+    identifier: SaveToDatabase
+```
+
+### Plugin
 
 A plugin is required for approval or dismiss of the consent. The
 associated page containing the plugin must then be specified in the

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact.form.yaml
@@ -23,6 +23,23 @@ finishers:
       message: 'Please approve your consent.'
       contentElementUid: ''
     identifier: Confirmation
+  -
+    options:
+      table: fe_users
+      mode: insert
+      databaseColumnMappings:
+        pid:
+          value: 1
+        tstamp:
+          value: '{__currentTimestamp}'
+        username:
+          value: 'consent {Consent.lastInsertedConsent.uid}'
+      elements:
+        email-1:
+          mapOnDatabaseColumn: email
+        fileupload-1:
+          mapOnDatabaseColumn: image
+    identifier: SaveToDatabase
 renderables:
   -
     renderingOptions:

--- a/Tests/Acceptance/Data/Fixtures/fe_users.sql
+++ b/Tests/Acceptance/Data/Fixtures/fe_users.sql
@@ -1,0 +1,2 @@
+DELETE FROM `fe_users`;
+ALTER TABLE `fe_users` AUTO_INCREMENT = 1;

--- a/Tests/Acceptance/Frontend/ConsentFinisherCest.php
+++ b/Tests/Acceptance/Frontend/ConsentFinisherCest.php
@@ -59,6 +59,35 @@ final class ConsentFinisherCest
         );
     }
 
+    public function canUseLastInsertedConsentFromFinisherVariableProvider(AcceptanceTester $I): void
+    {
+        $numberOfFormFixtures = $this->getNumberOfFormFixtures($I);
+
+        $I->fillAndSubmitForm(Form::DEFAULT, true);
+
+        $I->waitForText('Please approve your consent.', 5);
+
+        $uid = $I->grabFromDatabase(
+            Consent::TABLE_NAME,
+            'uid',
+            [
+                'data' => '{"email-1":"user@example.com","fileupload-1":' . ($numberOfFormFixtures + 1) . '}',
+                'email' => 'user@example.com',
+                'form_persistence_identifier' => '1:/form_definitions/contact.form.yaml',
+                'original_content_element_uid' => 1,
+            ]
+        );
+
+        $I->seeInDatabase(
+            'fe_users',
+            [
+                'username' => 'consent ' . $uid,
+                'email' => 'user@example.com',
+                'image' => $numberOfFormFixtures + 1,
+            ]
+        );
+    }
+
     public function receiveConsentMail(AcceptanceTester $I): void
     {
         $I->fillAndSubmitForm();


### PR DESCRIPTION
With this PR, the last inserted consent is now populated with the finisher variable provider. Consumers can access the consent in `.form.yaml` configuration via `{Consent.lastInsertedConsent}` or in finisher context via

```php
/** @var \EliasHaeussler\Typo3FormConsent\Domain\Model\Consent|null $lastInsertedConsent */
$lastInsertedConsent = $this->finisherContext->getFinisherVariableProvider()->get(
    $this->shortFinisherIdentifier,
    'lastInsertedConsent'
);
```

---

Resolves: #61