### PR TITLE
[!!!][FEATURE] Make FormRuntime available via ModifyConsent events

### DIFF
--- a/Classes/Domain/Factory/ConsentFactory.php
+++ b/Classes/Domain/Factory/ConsentFactory.php
@@ -91,7 +91,7 @@ final class ConsentFactory
         $consent->setValidationHash($this->hashService->generate($consent));
 
         // Dispatch ModifyConsent event
-        $this->eventDispatcher->dispatch(new ModifyConsentEvent($consent));
+        $this->eventDispatcher->dispatch(new ModifyConsentEvent($consent, $formRuntime));
 
         // Re-generate validation hash if consent has changed in the meantime
         if (!$this->hashService->isValid($consent)) {

--- a/Classes/Domain/Finishers/ConsentFinisher.php
+++ b/Classes/Domain/Finishers/ConsentFinisher.php
@@ -137,7 +137,7 @@ final class ConsentFinisher extends AbstractFinisher implements LoggerAwareInter
             ->add(RenderRenderableViewHelper::class, 'formRuntime', $formRuntime);
 
         // Dispatch ModifyConsentMail event
-        $this->eventDispatcher->dispatch(new ModifyConsentMailEvent($mail));
+        $this->eventDispatcher->dispatch(new ModifyConsentMailEvent($mail, $formRuntime));
 
         // Send mail
         try {

--- a/Classes/Event/ModifyConsentEvent.php
+++ b/Classes/Event/ModifyConsentEvent.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Event;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
+use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 
 /**
  * ModifyConsentEvent
@@ -34,14 +35,21 @@ use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 final class ModifyConsentEvent
 {
     private Consent $consent;
+    private FormRuntime $formRuntime;
 
-    public function __construct(Consent $consent)
+    public function __construct(Consent $consent, FormRuntime $formRuntime)
     {
         $this->consent = $consent;
+        $this->formRuntime = $formRuntime;
     }
 
     public function getConsent(): Consent
     {
         return $this->consent;
+    }
+
+    public function getFormRuntime(): FormRuntime
+    {
+        return $this->formRuntime;
     }
 }

--- a/Classes/Event/ModifyConsentMailEvent.php
+++ b/Classes/Event/ModifyConsentMailEvent.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Event;
 
 use TYPO3\CMS\Core\Mail\FluidEmail;
+use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 
 /**
  * ModifyConsentMailEvent
@@ -34,14 +35,21 @@ use TYPO3\CMS\Core\Mail\FluidEmail;
 final class ModifyConsentMailEvent
 {
     private FluidEmail $mail;
+    private FormRuntime $formRuntime;
 
-    public function __construct(FluidEmail $mail)
+    public function __construct(FluidEmail $mail, FormRuntime $formRuntime)
     {
         $this->mail = $mail;
+        $this->formRuntime = $formRuntime;
     }
 
     public function getMail(): FluidEmail
     {
         return $this->mail;
+    }
+
+    public function getFormRuntime(): FormRuntime
+    {
+        return $this->formRuntime;
     }
 }

--- a/Tests/Unit/Event/ModifyConsentEventTest.php
+++ b/Tests/Unit/Event/ModifyConsentEventTest.php
@@ -25,6 +25,8 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Event;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Event\ModifyConsentEvent;
+use Prophecy\PhpUnit\ProphecyTrait;
+use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -35,15 +37,19 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 final class ModifyConsentEventTest extends UnitTestCase
 {
+    use ProphecyTrait;
+
     protected ModifyConsentEvent $subject;
     protected Consent $consent;
+    protected FormRuntime $formRuntime;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->consent = new Consent();
-        $this->subject = new ModifyConsentEvent($this->consent);
+        $this->formRuntime = $this->prophesize(FormRuntime::class)->reveal();
+        $this->subject = new ModifyConsentEvent($this->consent, $this->formRuntime);
     }
 
     /**
@@ -53,5 +59,14 @@ final class ModifyConsentEventTest extends UnitTestCase
     {
         $expected = $this->consent;
         self::assertSame($expected, $this->subject->getConsent());
+    }
+
+    /**
+     * @test
+     */
+    public function getFormRuntimeReturnsInitialFormRuntime(): void
+    {
+        $expected = $this->formRuntime;
+        self::assertSame($expected, $this->subject->getFormRuntime());
     }
 }

--- a/Tests/Unit/Event/ModifyConsentMailEventTest.php
+++ b/Tests/Unit/Event/ModifyConsentMailEventTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Event;
 use EliasHaeussler\Typo3FormConsent\Event\ModifyConsentMailEvent;
 use Prophecy\PhpUnit\ProphecyTrait;
 use TYPO3\CMS\Core\Mail\FluidEmail;
+use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -40,13 +41,15 @@ final class ModifyConsentMailEventTest extends UnitTestCase
 
     protected ModifyConsentMailEvent $subject;
     protected FluidEmail $mail;
+    protected FormRuntime $formRuntime;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->mail = $this->prophesize(FluidEmail::class)->reveal();
-        $this->subject = new ModifyConsentMailEvent($this->mail);
+        $this->formRuntime = $this->prophesize(FormRuntime::class)->reveal();
+        $this->subject = new ModifyConsentMailEvent($this->mail, $this->formRuntime);
     }
 
     /**
@@ -56,5 +59,14 @@ final class ModifyConsentMailEventTest extends UnitTestCase
     {
         $expected = $this->mail;
         self::assertSame($expected, $this->subject->getMail());
+    }
+
+    /**
+     * @test
+     */
+    public function getFormRuntimeReturnsInitialFormRuntime(): void
+    {
+        $expected = $this->formRuntime;
+        self::assertSame($expected, $this->subject->getFormRuntime());
     }
 }


### PR DESCRIPTION
With this PR, the current `FormRuntime` instance is now populated with these events:

* `EliasHaeussler\Typo3FormConsent\Event\ModifyConsentEvent`
* `EliasHaeussler\Typo3FormConsent\Event\ModifyConsentMailEvent`

In an appropriate event listener, calling `$event->getFormRuntime()` accesses the current `FormRuntime` instance. This allows for further manipulation of the current `Consent`, e.g. by adding additional data extracted form a current form element state.

⚠️ This PR is considered **breaking**, because the constructor signature of mentioned classes has changed.

---

Related: #62