### PR TITLE
[BUGFIX] Align with latest changes in typo3/coding-standards

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -61,7 +61,7 @@ final class Configuration
      */
     private static function get(string $path)
     {
-        if (null === self::$configuration) {
+        if (self::$configuration === null) {
             try {
                 self::$configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(Extension::KEY);
             } catch (Exception $e) {

--- a/Classes/Configuration/Icon.php
+++ b/Classes/Configuration/Icon.php
@@ -51,7 +51,7 @@ final class Icon
         $pluginName = trim($pluginName);
         $pluginName = str_replace('_', '-', GeneralUtility::camelCaseToLowerCaseUnderscored($pluginName));
 
-        if ('' === $pluginName) {
+        if ($pluginName === '') {
             throw new \InvalidArgumentException(
                 'Plugin name must not be empty when generating icon plugin identifier.',
                 1587655457
@@ -79,7 +79,7 @@ final class Icon
         $widgetName = trim($widgetName);
         $widgetName = str_replace('_', '-', GeneralUtility::camelCaseToLowerCaseUnderscored($widgetName));
 
-        if ('' === $widgetName) {
+        if ($widgetName === '') {
             throw new \InvalidArgumentException(
                 'Widget name must not be empty when generating icon widget identifier.',
                 1632850400
@@ -102,7 +102,7 @@ final class Icon
         $fileName = trim($fileName);
         $type = trim($type) ?: 'svg';
 
-        if ('' === $fileName) {
+        if ($fileName === '') {
             throw new \InvalidArgumentException('No icon filename given.', 1580308459);
         }
 

--- a/Classes/Controller/ConsentController.php
+++ b/Classes/Controller/ConsentController.php
@@ -71,7 +71,7 @@ final class ConsentController extends ActionController
         $this->view->assign('consent', $consent);
 
         // Early return if consent could not be found
-        if (null === $consent) {
+        if ($consent === null) {
             return $this->createErrorResponse('invalidConsent');
         }
 
@@ -176,7 +176,7 @@ final class ConsentController extends ActionController
      */
     private function createHtmlResponse(ResponseInterface $previous = null): ResponseInterface
     {
-        if (null === $previous) {
+        if ($previous === null) {
             return $this->createResponse();
         }
 
@@ -187,7 +187,7 @@ final class ConsentController extends ActionController
 
         $content = (string)$previous->getBody();
 
-        if ('' !== trim($content)) {
+        if (trim($content) !== '') {
             return $this->createResponse($content);
         }
 

--- a/Classes/Domain/Factory/ConsentFactory.php
+++ b/Classes/Domain/Factory/ConsentFactory.php
@@ -122,7 +122,7 @@ final class ConsentFactory
     {
         $contentObjectRenderer = $this->configurationManager->getContentObject();
 
-        if (null !== $contentObjectRenderer) {
+        if ($contentObjectRenderer !== null) {
             return (int)($contentObjectRenderer->data['uid'] ?? 0);
         }
 

--- a/Classes/Domain/Finishers/ConsentFinisher.php
+++ b/Classes/Domain/Finishers/ConsentFinisher.php
@@ -163,7 +163,7 @@ final class ConsentFinisher extends AbstractFinisher implements LoggerAwareInter
 
         // Set the PSR-7 request object if available
         $serverRequest = $this->getServerRequest();
-        if (null !== $serverRequest) {
+        if ($serverRequest !== null) {
             $mail->setRequest($serverRequest);
         }
 

--- a/Classes/Domain/Finishers/FinisherOptions.php
+++ b/Classes/Domain/Finishers/FinisherOptions.php
@@ -123,7 +123,7 @@ final class FinisherOptions implements \ArrayAccess
         if (!\is_string($recipientAddress)) {
             $this->throwException('recipientAddress.invalid', 1640186663);
         }
-        if ('' === trim($recipientAddress)) {
+        if (trim($recipientAddress) === '') {
             $this->throwException('recipientAddress.empty', 1576947638);
         }
         if (!GeneralUtility::validEmail($recipientAddress)) {
@@ -150,7 +150,7 @@ final class FinisherOptions implements \ArrayAccess
         if (!\is_string($senderAddress)) {
             $this->throwException('senderAddress.invalid', 1640186811);
         }
-        if ('' !== trim($senderAddress) && !GeneralUtility::validEmail($senderAddress)) {
+        if (trim($senderAddress) !== '' && !GeneralUtility::validEmail($senderAddress)) {
             $this->throwException('senderAddress.invalid', 1587842752);
         }
 
@@ -266,7 +266,7 @@ final class FinisherOptions implements \ArrayAccess
 
     private function getPageRepository(): PageRepository
     {
-        if (null === self::$pageRepository) {
+        if (self::$pageRepository === null) {
             self::$pageRepository = GeneralUtility::makeInstance(PageRepository::class);
         }
 

--- a/Classes/Domain/Model/Consent.php
+++ b/Classes/Domain/Model/Consent.php
@@ -173,7 +173,7 @@ class Consent extends AbstractEntity
 
     public function isApproved(): bool
     {
-        return null !== $this->state && $this->state->isApproved();
+        return $this->state !== null && $this->state->isApproved();
     }
 
     public function setApproved(): self
@@ -186,7 +186,7 @@ class Consent extends AbstractEntity
 
     public function isDismissed(): bool
     {
-        return null !== $this->state && $this->state->isDismissed();
+        return $this->state !== null && $this->state->isDismissed();
     }
 
     public function setDismissed(): self

--- a/Classes/Event/Listener/InvokeFinishersListener.php
+++ b/Classes/Event/Listener/InvokeFinishersListener.php
@@ -73,7 +73,7 @@ final class InvokeFinishersListener
         // or no finisher variants are configured
         if (
             empty($consent->getOriginalRequestParameters())
-            || 0 === $consent->getOriginalContentElementUid()
+            || $consent->getOriginalContentElementUid() === 0
             || !$this->areFinisherVariantsConfigured($consent->getFormPersistenceIdentifier(), $condition)
         ) {
             return null;
@@ -143,7 +143,7 @@ final class InvokeFinishersListener
     private function fetchOriginalContentElementRecord(int $contentElementUid): ?array
     {
         // Early return if content element UID cannot be  determined
-        if (0 === $contentElementUid) {
+        if ($contentElementUid === 0) {
             return null;
         }
 

--- a/Classes/Http/StringableResponse.php
+++ b/Classes/Http/StringableResponse.php
@@ -35,7 +35,7 @@ final class StringableResponse extends Response
 {
     public function __toString(): string
     {
-        if (null === $this->body) {
+        if ($this->body === null) {
             return '';
         }
 

--- a/Classes/Service/HashService.php
+++ b/Classes/Service/HashService.php
@@ -48,10 +48,10 @@ final class HashService
         $hashComponents = [
             $consent->getDate()->getTimestamp(),
         ];
-        if (null !== $consent->getData()) {
+        if ($consent->getData() !== null) {
             $hashComponents[] = (string)$consent->getData();
         }
-        if (null !== $consent->getValidUntil()) {
+        if ($consent->getValidUntil() !== null) {
             $hashComponents[] = $consent->getValidUntil()->getTimestamp();
         }
 

--- a/Classes/Type/ConsentStateType.php
+++ b/Classes/Type/ConsentStateType.php
@@ -76,17 +76,17 @@ final class ConsentStateType implements TypeInterface
 
     public function isNew(): bool
     {
-        return self::NEW === $this->state;
+        return $this->state === self::NEW;
     }
 
     public function isApproved(): bool
     {
-        return self::APPROVED === $this->state;
+        return $this->state === self::APPROVED;
     }
 
     public function isDismissed(): bool
     {
-        return self::DISMISSED === $this->state;
+        return $this->state === self::DISMISSED;
     }
 
     public function __toString(): string

--- a/Classes/Type/Transformer/FormRequestTypeTransformer.php
+++ b/Classes/Type/Transformer/FormRequestTypeTransformer.php
@@ -53,7 +53,7 @@ final class FormRequestTypeTransformer implements TypeTransformerInterface
      */
     public function transform(FormRuntime $formRuntime = null): JsonType
     {
-        if (null === $formRuntime) {
+        if ($formRuntime === null) {
             throw new \InvalidArgumentException('Expected a valid FormRuntime object, NULL given.', 1646044629);
         }
 

--- a/Classes/Type/Transformer/FormValuesTypeTransformer.php
+++ b/Classes/Type/Transformer/FormValuesTypeTransformer.php
@@ -43,13 +43,13 @@ final class FormValuesTypeTransformer implements TypeTransformerInterface
      */
     public function transform(FormRuntime $formRuntime = null): JsonType
     {
-        if (null === $formRuntime) {
+        if ($formRuntime === null) {
             throw new \InvalidArgumentException('Expected a valid FormRuntime object, NULL given.', 1646044591);
         }
 
         // Early return if form state is not available
         $formState = $formRuntime->getFormState();
-        if (null === $formState) {
+        if ($formState === null) {
             return JsonType::fromArray([]);
         }
 
@@ -80,7 +80,7 @@ final class FormValuesTypeTransformer implements TypeTransformerInterface
         $excludedElements = Configuration::getExcludedElementsFromPersistence();
         $element = $formRuntime->getFormDefinition()->getElementByIdentifier($elementIdentifier);
 
-        return null !== $element && \in_array($element->getType(), $excludedElements, true);
+        return $element !== null && \in_array($element->getType(), $excludedElements, true);
     }
 
     public static function getName(): string

--- a/Classes/Updates/MigrateConsentStateUpgradeWizard.php
+++ b/Classes/Updates/MigrateConsentStateUpgradeWizard.php
@@ -143,7 +143,7 @@ final class MigrateConsentStateUpgradeWizard implements UpgradeWizardInterface, 
             );
         }
 
-        return 1 === $this->connection->update(Consent::TABLE_NAME, $record, ['uid' => $uid]);
+        return $this->connection->update(Consent::TABLE_NAME, $record, ['uid' => $uid]) === 1;
     }
 
     /**
@@ -152,7 +152,7 @@ final class MigrateConsentStateUpgradeWizard implements UpgradeWizardInterface, 
     private function migrateState(array &$record): bool
     {
         // Early return if state was already migrated
-        if (ConsentStateType::NEW !== (int)$record['state']) {
+        if ((int)$record['state'] !== ConsentStateType::NEW) {
             return false;
         }
 
@@ -169,7 +169,7 @@ final class MigrateConsentStateUpgradeWizard implements UpgradeWizardInterface, 
         }
 
         // Dismissed consent
-        if ($record['deleted'] && null === $record['data']) {
+        if ($record['deleted'] && $record['data'] === null) {
             $record['state'] = ConsentStateType::DISMISSED;
 
             return true;

--- a/Tests/Acceptance/Frontend/ConsentFinisherCest.php
+++ b/Tests/Acceptance/Frontend/ConsentFinisherCest.php
@@ -156,7 +156,7 @@ final class ConsentFinisherCest
     {
         $fixtureFiles = glob(\dirname(__DIR__) . '/Data/Fileadmin/form_definitions/*.form.yaml');
 
-        if (false === $fixtureFiles) {
+        if ($fixtureFiles === false) {
             $I->fail('Unable to determine number of form fixtures.');
 
             // Actually, this is superfluous as $I->fail() exists and will never

--- a/Tests/Acceptance/Support/Helper/Email.php
+++ b/Tests/Acceptance/Support/Helper/Email.php
@@ -65,7 +65,7 @@ final class Email extends Module
 
         $urls = $this->extractUrlsFromEmailBody();
 
-        if (null !== $count) {
+        if ($count !== null) {
             $I->assertCount($count, $urls);
         } else {
             $I->assertNotEmpty($urls);

--- a/Tests/Acceptance/Support/Helper/Form.php
+++ b/Tests/Acceptance/Support/Helper/Form.php
@@ -70,7 +70,7 @@ final class Form extends Module
 
     private function getFormElementIdentifier(string $form, string $element = null): string
     {
-        return $form . (null !== $element ? '-' . $element : '');
+        return $form . ($element !== null ? '-' . $element : '');
     }
 
     private function getFormElementName(string $form, string $element = null): string
@@ -79,7 +79,7 @@ final class Form extends Module
             $form => [],
         ];
 
-        if (null !== $element) {
+        if ($element !== null) {
             $nameParts[$form][$element] = null;
         }
 

--- a/Tests/Functional/ExpressionLanguage/FunctionsProvider/ConsentConditionFunctionsProviderTest.php
+++ b/Tests/Functional/ExpressionLanguage/FunctionsProvider/ConsentConditionFunctionsProviderTest.php
@@ -121,7 +121,7 @@ final class ConsentConditionFunctionsProviderTest extends FunctionalTestCase
     {
         $variables = [];
 
-        if (null !== $formRuntime) {
+        if ($formRuntime !== null) {
             $variables['formRuntime'] = $formRuntime;
         }
 


### PR DESCRIPTION
With TYPO3/coding-standards#31, yoda-style conditions were explicitly disabled. This PR aligns the code base with the updated coding-standards package.