### PR TITLE
[BUGFIX] Disallow installation of TYPO3 11.5.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
 		"typo3/coding-standards": "^0.5.0",
 		"typo3/testing-framework": "^6.14"
 	},
+	"conflict": {
+		"typo3/cms-form": ">= 11.5.13"
+	},
 	"suggest": {
 		"typo3/cms-dashboard": "Adds a custom form consent widget to the TYPO3 dashboard (~10.4.11 || ~11.5.1)",
 		"typo3/cms-scheduler": "Allows garbage collection of expired consents (~10.4.11 || ~11.5.1)"


### PR DESCRIPTION
With TYPO3/typo3@9f933f2, a new `FormRequestHandler` was introduced. It provides a new centralized place to render forms. With this change, all logic that resided in the `<formvh:render>` view helper was moved to the new class. However, the new request handler does now actively hide the current content object renderer instance. This means, EXT:form_consent will no longer be able to fetch the current content element UID since this is only available in the original `ContentObjectRenderer`.

Until this bug is fixed, installation of TYPO3 11.5.13 is not possible since it limits the features provided by EXT:form_consent and therefore leads to unexpected behavior of the extension.

⚠️ Consumers making use of this extension should **consider downgrading to TYPO3 11.5.12** if they rely on the full feature set of EXT:form_consent. ⚠️ 