### PR TITLE
[BUGFIX] Avoid installation of TYPO3 11.5.13+ via ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -31,7 +31,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '0.6.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.11-11.5.99',
+            'typo3' => '10.4.11-11.5.12',
         ],
     ],
 ];


### PR DESCRIPTION
As a follow-up to #69, installation of this extension via extension manager is now also prohibited via `ext_emconf.php` for TYPO3 11.5.13 and later. Reasons are explained in said PR.