### PR TITLE
[BUGFIX] Allow installation of EXT:form >= 11.5.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,6 @@
 
 ---
 
-> **Note**
->
-> Installation with **TYPO3 11.5.13, 11.5.14 and 11.5.15** is currently **not possible**.
->
-> Read more at https://github.com/eliashaeussler/typo3-form-consent/pull/69
-> and consider downgrading to TYPO3 11.5.12.
-
----
-
 An extension for TYPO3 CMS that adds double opt-in functionality to
 EXT:form. It allows the dynamic adaptation of the entire double opt-in
 process using various events. In addition, the extension integrates

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
 		"typo3/testing-framework": "^6.14"
 	},
 	"conflict": {
-		"typo3/cms-form": ">= 11.5.13"
+		"typo3/cms-form": "11.5.13 - 11.5.15"
 	},
 	"suggest": {
 		"typo3/cms-dashboard": "Adds a custom form consent widget to the TYPO3 dashboard (~10.4.11 || ~11.5.1)",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -31,7 +31,10 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '0.6.2',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.11-11.5.12',
+            'typo3' => '10.4.11-11.5.99',
+        ],
+        'conflicts' => [
+            'typo3' => '11.5.13-11.5.15',
         ],
     ],
 ];


### PR DESCRIPTION
The initial TYPO3 patch released with 11.5.13 (outlined in #69) has been reverted and included in the latest TYPO3 release 11.5.16. Therefore, 11.5.16 and further versions can now be used together with EXT:form_consent. However, affected versions 11.5.13, 11.5.14 and 11.5.15 are added to `conflicts` to avoid usage of EXT:form_consent along with those TYPO3 versions.

Related: #69