### PR TITLE
[BUGFIX] Skip upgrade wizard if no more legacy columns are to be migrated

### DIFF
--- a/Classes/Updates/MigrateConsentStateUpgradeWizard.php
+++ b/Classes/Updates/MigrateConsentStateUpgradeWizard.php
@@ -264,6 +264,11 @@ final class MigrateConsentStateUpgradeWizard implements UpgradeWizardInterface, 
         $queryBuilder = $this->connection->createQueryBuilder()->from(Consent::TABLE_NAME);
         $queryBuilder->getRestrictions()->removeAll();
 
+        // Early return if no legacy columns are given
+        if ($legacyColumns === []) {
+            return $queryBuilder->andWhere('0=1');
+        }
+
         foreach ($legacyColumns as $legacyColumn) {
             switch ($legacyColumn) {
                 case 'approved':


### PR DESCRIPTION
If no more legacy columns are available in the database, the upgrade wizard to migrate consent state must not be executed.

Resolves: #79