### PR TITLE
[TASK] Use composer-unused 0.7 in CI

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -20,7 +20,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
-          tools: composer:v2, composer-require-checker, composer-unused
+          # @todo switch back to composer-unused 0.8 once https://github.com/composer-unused/composer-unused/issues/444 is resolved
+          tools: composer:v2, composer-require-checker, composer-unused:0.7
           coverage: none
 
       # Validation


### PR DESCRIPTION
Can be reverted once composer-unused/composer-unused#444 is resolved.