### PR TITLE
[TASK] Switch to `ddev/github-action-setup-ddev`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,7 +37,7 @@ jobs:
 
       # Setup DDEV
       - name: Setup DDEV
-        uses: jonaseberle/github-action-setup-ddev@v1
+        uses: ddev/github-action-setup-ddev@v1
         with:
           autostart: false
       - name: Configure and start DDEV
@@ -81,7 +81,7 @@ jobs:
 
       # Setup DDEV
       - name: Setup DDEV
-        uses: jonaseberle/github-action-setup-ddev@v1
+        uses: ddev/github-action-setup-ddev@v1
         with:
           autostart: false
       - name: Configure and start DDEV


### PR DESCRIPTION
The `jonaseberle/github-action-setup-ddev` action was replaced by `ddev/github-action-setup-ddev` and is now deprecated. Thus, we switch to the new, official action.