### PR TITLE
[TASK] Use `CoversClass` attribute in tests

### DIFF
--- a/Tests/Functional/Configuration/ConfigurationTest.php
+++ b/Tests/Functional/Configuration/ConfigurationTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Configuration;
 
 use EliasHaeussler\Typo3FormConsent\Configuration\Configuration;
 use EliasHaeussler\Typo3FormConsent\Configuration\Extension;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -36,6 +37,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(Configuration::class)]
 final class ConfigurationTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;

--- a/Tests/Functional/Configuration/IconTest.php
+++ b/Tests/Functional/Configuration/IconTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Configuration;
 
 use EliasHaeussler\Typo3FormConsent\Configuration\Icon;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 use TYPO3\CMS\Core\Imaging\IconRegistry;
@@ -35,6 +36,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(Icon::class)]
 final class IconTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;

--- a/Tests/Functional/Configuration/LocalizationTest.php
+++ b/Tests/Functional/Configuration/LocalizationTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Configuration;
 
 use EliasHaeussler\Typo3FormConsent\Configuration\Localization;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Constraint\IsType;
@@ -38,6 +39,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(Localization::class)]
 final class LocalizationTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;

--- a/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
+++ b/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Domain\Finishers;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Finishers\FinisherOptions;
 use EliasHaeussler\Typo3FormConsent\Exception\NotAllowedException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Fluid\View\TemplatePaths;
@@ -37,6 +38,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(FinisherOptions::class)]
 final class FinisherOptionsTest extends FunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [

--- a/Tests/Functional/Domain/Repository/ConsentRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ConsentRepositoryTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Domain\Repository;
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Domain\Repository\ConsentRepository;
 use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -36,6 +37,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(ConsentRepository::class)]
 final class ConsentRepositoryTest extends FunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [

--- a/Tests/Functional/ExpressionLanguage/FunctionsProvider/ConsentConditionFunctionsProviderTest.php
+++ b/Tests/Functional/ExpressionLanguage/FunctionsProvider/ConsentConditionFunctionsProviderTest.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\ExpressionLanguage\FunctionsProvider;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
+use EliasHaeussler\Typo3FormConsent\ExpressionLanguage\FunctionsProvider\ConsentConditionFunctionsProvider;
 use EliasHaeussler\Typo3FormConsent\Registry\ConsentManagerRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\ExpressionLanguage\Resolver;
 use TYPO3\CMS\Form\Domain\Model\FormDefinition;
@@ -37,6 +39,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(ConsentConditionFunctionsProvider::class)]
 final class ConsentConditionFunctionsProviderTest extends FunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [

--- a/Tests/Functional/Service/HashServiceTest.php
+++ b/Tests/Functional/Service/HashServiceTest.php
@@ -27,6 +27,7 @@ use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Event\GenerateHashEvent;
 use EliasHaeussler\Typo3FormConsent\Service\HashService;
 use EliasHaeussler\Typo3FormConsent\Type\JsonType;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\DependencyInjection\Container;
@@ -39,6 +40,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(HashService::class)]
 final class HashServiceTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;

--- a/Tests/Functional/Type/Transformer/FormRequestTypeTransformerTest.php
+++ b/Tests/Functional/Type/Transformer/FormRequestTypeTransformerTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Type\Transformer;
 
 use EliasHaeussler\Typo3FormConsent\Type\Transformer\FormRequestTypeTransformer;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -34,6 +35,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(FormRequestTypeTransformer::class)]
 final class FormRequestTypeTransformerTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;

--- a/Tests/Functional/Type/Transformer/FormValuesTypeTransformerTest.php
+++ b/Tests/Functional/Type/Transformer/FormValuesTypeTransformerTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Type\Transformer;
 
 use EliasHaeussler\Typo3FormConsent\Type\JsonType;
 use EliasHaeussler\Typo3FormConsent\Type\Transformer\FormValuesTypeTransformer;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -35,6 +36,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(FormValuesTypeTransformer::class)]
 final class FormValuesTypeTransformerTest extends FunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [

--- a/Tests/Functional/Widget/Provider/ConsentChartDataProviderTest.php
+++ b/Tests/Functional/Widget/Provider/ConsentChartDataProviderTest.php
@@ -26,8 +26,8 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Widget\Provider;
 use Doctrine\DBAL\DBALException;
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Widget\Provider\ConsentChartDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3\TestingFramework\Core\Exception;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -36,6 +36,7 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(ConsentChartDataProvider::class)]
 final class ConsentChartDataProviderTest extends FunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [
@@ -52,7 +53,6 @@ final class ConsentChartDataProviderTest extends FunctionalTestCase
 
     /**
      * @throws DBALException
-     * @throws Exception
      */
     protected function setUp(): void
     {

--- a/Tests/Unit/Configuration/IconTest.php
+++ b/Tests/Unit/Configuration/IconTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Configuration;
 
 use EliasHaeussler\Typo3FormConsent\Configuration\Icon;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -34,6 +35,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(Icon::class)]
 final class IconTest extends UnitTestCase
 {
     #[Test]

--- a/Tests/Unit/Domain/Model/ConsentTest.php
+++ b/Tests/Unit/Domain/Model/ConsentTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Domain\Model;
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Type\ConsentStateType;
 use EliasHaeussler\Typo3FormConsent\Type\JsonType;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -35,6 +36,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(Consent::class)]
 final class ConsentTest extends UnitTestCase
 {
     protected Consent $subject;

--- a/Tests/Unit/Event/ApproveConsentEventTest.php
+++ b/Tests/Unit/Event/ApproveConsentEventTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Event;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Event\ApproveConsentEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -35,6 +36,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(ApproveConsentEvent::class)]
 final class ApproveConsentEventTest extends UnitTestCase
 {
     protected ApproveConsentEvent $subject;

--- a/Tests/Unit/Event/DismissConsentEventTest.php
+++ b/Tests/Unit/Event/DismissConsentEventTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Event;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Event\DismissConsentEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -35,6 +36,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(DismissConsentEvent::class)]
 final class DismissConsentEventTest extends UnitTestCase
 {
     protected DismissConsentEvent $subject;

--- a/Tests/Unit/Event/GenerateHashEventTest.php
+++ b/Tests/Unit/Event/GenerateHashEventTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Event;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Event\GenerateHashEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -34,6 +35,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(GenerateHashEvent::class)]
 final class GenerateHashEventTest extends UnitTestCase
 {
     protected GenerateHashEvent $subject;

--- a/Tests/Unit/Event/ModifyConsentEventTest.php
+++ b/Tests/Unit/Event/ModifyConsentEventTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Event;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Event\ModifyConsentEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -35,6 +36,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(ModifyConsentEvent::class)]
 final class ModifyConsentEventTest extends UnitTestCase
 {
     protected ModifyConsentEvent $subject;

--- a/Tests/Unit/Event/ModifyConsentMailEventTest.php
+++ b/Tests/Unit/Event/ModifyConsentMailEventTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Event;
 
 use EliasHaeussler\Typo3FormConsent\Event\ModifyConsentMailEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Mail\FluidEmail;
 use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
@@ -35,6 +36,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(ModifyConsentMailEvent::class)]
 final class ModifyConsentMailEventTest extends UnitTestCase
 {
     protected ModifyConsentMailEvent $subject;

--- a/Tests/Unit/Exception/NotAllowedExceptionTest.php
+++ b/Tests/Unit/Exception/NotAllowedExceptionTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Exception;
 
 use EliasHaeussler\Typo3FormConsent\Exception\NotAllowedException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -33,6 +34,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(NotAllowedException::class)]
 final class NotAllowedExceptionTest extends UnitTestCase
 {
     #[Test]

--- a/Tests/Unit/Exception/UnsupportedTypeExceptionTest.php
+++ b/Tests/Unit/Exception/UnsupportedTypeExceptionTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Exception;
 
 use EliasHaeussler\Typo3FormConsent\Exception\UnsupportedTypeException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -33,6 +34,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(UnsupportedTypeException::class)]
 final class UnsupportedTypeExceptionTest extends UnitTestCase
 {
     #[Test]

--- a/Tests/Unit/Registry/ConsentManagerRegistryTest.php
+++ b/Tests/Unit/Registry/ConsentManagerRegistryTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Registry;
 
 use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
 use EliasHaeussler\Typo3FormConsent\Registry\ConsentManagerRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -34,6 +35,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(ConsentManagerRegistry::class)]
 final class ConsentManagerRegistryTest extends UnitTestCase
 {
     protected Consent $consent;

--- a/Tests/Unit/Type/ConsentStateTypeTest.php
+++ b/Tests/Unit/Type/ConsentStateTypeTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Type;
 use EliasHaeussler\Typo3FormConsent\Exception\InvalidStateException;
 use EliasHaeussler\Typo3FormConsent\Type\ConsentStateType;
 use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
@@ -36,6 +37,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(ConsentStateType::class)]
 final class ConsentStateTypeTest extends UnitTestCase
 {
     protected ConsentStateType $subject;

--- a/Tests/Unit/Type/JsonTypeTest.php
+++ b/Tests/Unit/Type/JsonTypeTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Type;
 
 use EliasHaeussler\Typo3FormConsent\Type\JsonType;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -33,6 +34,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(JsonType::class)]
 final class JsonTypeTest extends UnitTestCase
 {
     /**

--- a/Tests/Unit/Type/Transformer/TypeTransformerFactoryTest.php
+++ b/Tests/Unit/Type/Transformer/TypeTransformerFactoryTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Type\Transformer;
 use EliasHaeussler\Typo3FormConsent\Exception\UnsupportedTypeException;
 use EliasHaeussler\Typo3FormConsent\Type\Transformer\FormRequestTypeTransformer;
 use EliasHaeussler\Typo3FormConsent\Type\Transformer\TypeTransformerFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use TYPO3\CMS\Extbase\Security\Cryptography\HashService;
@@ -37,6 +38,7 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
+#[CoversClass(TypeTransformerFactory::class)]
 final class TypeTransformerFactoryTest extends UnitTestCase
 {
     protected FormRequestTypeTransformer $formRequestTypeTransformer;


### PR DESCRIPTION
This PR adds PHPUnit's `CoversClass` attribute to all tests.