### PR TITLE
[TASK] Omit event class from listener registration

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -25,11 +25,9 @@ services:
     tags:
       - name: event.listener
         identifier: 'formConsentInvokeFinishersOnConsentApproveListener'
-        event: EliasHaeussler\Typo3FormConsent\Event\ApproveConsentEvent
         method: 'onConsentApprove'
       - name: event.listener
         identifier: 'formConsentInvokeFinishersOnConsentDismissListener'
-        event: EliasHaeussler\Typo3FormConsent\Event\DismissConsentEvent
         method: 'onConsentDismiss'
 
   connection.tx_formconsent_domain_model_consent:


### PR DESCRIPTION
Since TYPO3 fetches the related event class via reflection, it can be safely omitted from listener registration in `Services.yaml`.