### PR TITLE
[BUGFIX] Autowire class dependencies of dashboard widget

### DIFF
--- a/Classes/DependencyInjection/DashboardServicesConfigurator.php
+++ b/Classes/DependencyInjection/DashboardServicesConfigurator.php
@@ -57,6 +57,7 @@ final class DashboardServicesConfigurator
     {
         // Widget "approved consents"
         $this->services->set(self::APPROVED_CONSENTS_WIDGET)
+            ->autowire()
             ->class(ApprovedConsentsWidget::class)
             ->arg('$view', new Reference('dashboard.views.widget'))
             ->arg('$dataProvider', new Reference(self::APPROVED_CONSENTS_DATA_PROVIDER))


### PR DESCRIPTION
Dashboard widgets need proper dependency injection, therefore autowiring custom widgets is necessary unless dependencies are not injected manually. This seems to have changed with TYPO3 v12. With this PR, autowiring for class dependencies of the dashboard widget is now explicitly enabled.