### PR TITLE
[TASK] Move selectors in acceptance tests to dedicated enum

### DIFF
--- a/Tests/Acceptance/Backend/ApprovedConsentsWidgetCest.php
+++ b/Tests/Acceptance/Backend/ApprovedConsentsWidgetCest.php
@@ -21,10 +21,11 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace Acceptance\Backend;
+namespace EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Backend;
 
-use EliasHaeussler\Typo3CodeceptionHelper\Enums\Selectors;
+use EliasHaeussler\Typo3CodeceptionHelper\Enums\Selectors as CodeceptionHelperSelectors;
 use EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\AcceptanceTester;
+use EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Enums\Selectors;
 use EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Helper\ModalDialog;
 use EliasHaeussler\Typo3FormConsent\Widget\Provider\ConsentChartDataProvider;
 use TYPO3\CMS\Core\Information\Typo3Version;
@@ -61,18 +62,18 @@ final class ApprovedConsentsWidgetCest
         $this->logInToBackend($I);
         $this->addWidget($I, $dialog);
 
-        $I->waitForElementVisible('.widget-identifier-approvedConsentsWidget canvas');
+        $canvasSelector = Selectors::DashboardWidgetCanvas->value;
 
-        $data = $I->executeJS(
-            <<<JS
+        $I->waitForElementVisible($canvasSelector);
+
+        $data = $I->executeJS(<<<JS
 return await import('@typo3/dashboard/contrib/chartjs.js').then((chartjs) => {
-    const node = document.querySelector('.widget-identifier-approvedConsentsWidget canvas');
+    const node = document.querySelector('$canvasSelector');
     const chart = chartjs.Chart.getChart(node);
 
     return chart.config.data.datasets[0].data;
 });
-JS
-        );
+JS);
 
         /* @see ConsentChartDataProvider::getChartData() */
         $expected = [
@@ -86,14 +87,14 @@ JS
 
     private function addWidget(AcceptanceTester $I, ModalDialog $dialog): void
     {
-        $I->click('.js-dashboard-addWidget');
+        $I->click(Selectors::DashboardAddWidgetButton->value);
 
         $dialog->canSeeDialog();
 
-        $I->see('Form consent', '.dashboard-modal-item-title');
+        $I->see('Form consent', Selectors::DashboardModalItemTitle->value);
         $I->click('Form consent');
-        $I->switchToIFrame(Selectors::BackendContentFrame->value);
-        $I->waitForElementVisible('.widget-identifier-approvedConsentsWidget');
+        $I->switchToIFrame(CodeceptionHelperSelectors::BackendContentFrame->value);
+        $I->waitForElementVisible(Selectors::DashboardWidget->value);
     }
 
     private function createConsents(AcceptanceTester $I): void
@@ -136,10 +137,10 @@ JS
     private function logInToBackend(AcceptanceTester $I): void
     {
         if ($this->typo3Version->getMajorVersion() >= 12) {
-            $moduleIdentifier = '[data-modulemenu-identifier="dashboard"]';
+            $moduleIdentifier = Selectors::DashboardModule->value;
         } else {
             // @todo Remove once support for TYPO3 v11 is dropped
-            $moduleIdentifier = '#dashboard';
+            $moduleIdentifier = Selectors::DashboardModuleV11->value;
         }
 
         $I->loginAs('admin');

--- a/Tests/Acceptance/Backend/ConsentDataElementCest.php
+++ b/Tests/Acceptance/Backend/ConsentDataElementCest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Backend;
 
 use EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\AcceptanceTester;
+use EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Enums\Selectors;
 use TYPO3\CMS\Core\Information\Typo3Version;
 
 /**
@@ -39,10 +40,10 @@ final class ConsentDataElementCest
         $typo3Version = new Typo3Version();
 
         if ($typo3Version->getMajorVersion() >= 12) {
-            $moduleIdentifier = '[data-modulemenu-identifier="web_list"]';
+            $moduleIdentifier = Selectors::ListModule->value;
         } else {
             // @todo Remove once support for TYPO3 v11 is dropped
-            $moduleIdentifier = '#web_list';
+            $moduleIdentifier = Selectors::ListModuleV11->value;
         }
 
         $I->amOnPage('/');
@@ -51,8 +52,8 @@ final class ConsentDataElementCest
         $I->loginAs('admin');
         $I->openModule($moduleIdentifier);
 
-        $I->seeElement('#t3-table-tx_formconsent_domain_model_consent');
-        $I->click('tr[data-table="tx_formconsent_domain_model_consent"]:first-child td.col-title a');
+        $I->seeElement(Selectors::ConsentListCollapsible->value);
+        $I->click(Selectors::ConsentListItemTitle->value);
         $I->waitForText('Submitted form data', 5);
     }
 }

--- a/Tests/Acceptance/Backend/FormEditorCest.php
+++ b/Tests/Acceptance/Backend/FormEditorCest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Backend;
 
 use EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\AcceptanceTester;
+use EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Enums\Selectors;
 use TYPO3\CMS\Core\Information\Typo3Version;
 
 /**
@@ -39,21 +40,21 @@ final class FormEditorCest
         $typo3Version = new Typo3Version();
 
         if ($typo3Version->getMajorVersion() >= 12) {
-            $moduleIdentifier = '[data-modulemenu-identifier="web_FormFormbuilder"]';
+            $moduleIdentifier = Selectors::FormModule->value;
         } else {
             // @todo Remove once support for TYPO3 v11 is dropped
-            $moduleIdentifier = '#web_FormFormbuilder';
+            $moduleIdentifier = Selectors::FormModuleV11->value;
         }
 
         $I->loginAs('admin');
         $I->openModule($moduleIdentifier);
 
         $I->waitForText('contact');
-        $I->click('contact', '#forms');
+        $I->click('contact', Selectors::FormList->value);
 
-        $I->waitForText('contact', 5, '#t3-form-form-definition-label');
-        $I->seeElement('[title="Preview mode"]');
-        $I->click('[title="Preview mode"]');
-        $I->waitForElement('form#contact');
+        $I->waitForText('contact', 5, Selectors::FormDefinition->value);
+        $I->seeElement(Selectors::FormPreviewMode->value);
+        $I->click(Selectors::FormPreviewMode->value);
+        $I->waitForElement(Selectors::ContactForm->value);
     }
 }

--- a/Tests/Acceptance/Support/Enums/Selectors.php
+++ b/Tests/Acceptance/Support/Enums/Selectors.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Enums;
+
+/**
+ * Selectors
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+enum Selectors: string
+{
+    case ConsentListCollapsible = '#t3-table-tx_formconsent_domain_model_consent';
+    case ConsentListItemTitle = 'tr[data-table="tx_formconsent_domain_model_consent"]:first-child td.col-title a';
+    case ContactForm = 'form#contact';
+    case DashboardAddWidgetButton = '.js-dashboard-addWidget';
+    case DashboardModalItemTitle = '.dashboard-modal-item-title';
+    case DashboardModule = '[data-modulemenu-identifier="dashboard"]';
+    case DashboardWidget = '.widget-identifier-approvedConsentsWidget';
+    case DashboardWidgetCanvas = '.widget-identifier-approvedConsentsWidget canvas';
+    case FormDefinition = '#t3-form-form-definition-label';
+    case FormList = '#forms';
+    case FormModule = '[data-modulemenu-identifier="web_FormFormbuilder"]';
+    case FormPreviewMode = '[title="Preview mode"]';
+    case ListModule = '[data-modulemenu-identifier="web_list"]';
+
+    // @todo Can be removed once support for TYPO3 v11 is dropped
+    case DashboardModuleV11 = '#dashboard';
+    case FormModuleV11 = '#web_FormFormbuilder';
+    case ListModuleV11 = '#web_list';
+}


### PR DESCRIPTION
This PR moves all DOM selectors used in acceptance tests to a dedicated `Selectors` enum.