### PR TITLE
[TASK] Move Extension class to extension root namespace

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3FormConsent\Configuration;
 
+use EliasHaeussler\Typo3FormConsent\Extension;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Exception;
 use TYPO3\CMS\Core\Utility\ArrayUtility;

--- a/Classes/Configuration/Icon.php
+++ b/Classes/Configuration/Icon.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3FormConsent\Configuration;
 
+use EliasHaeussler\Typo3FormConsent\Extension;
 use InvalidArgumentException;
 use TYPO3\CMS\Core\Imaging\IconRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;

--- a/Classes/Configuration/Localization.php
+++ b/Classes/Configuration/Localization.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3FormConsent\Configuration;
 
+use EliasHaeussler\Typo3FormConsent\Extension;
 use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;

--- a/Classes/Domain/Finishers/FinisherOptions.php
+++ b/Classes/Domain/Finishers/FinisherOptions.php
@@ -24,9 +24,9 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Domain\Finishers;
 
 use ArrayAccess;
-use EliasHaeussler\Typo3FormConsent\Configuration\Extension;
 use EliasHaeussler\Typo3FormConsent\Configuration\Localization;
 use EliasHaeussler\Typo3FormConsent\Exception\NotAllowedException;
+use EliasHaeussler\Typo3FormConsent\Extension;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;

--- a/Classes/Extension.php
+++ b/Classes/Extension.php
@@ -21,12 +21,8 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3FormConsent\Configuration;
+namespace EliasHaeussler\Typo3FormConsent;
 
-use EliasHaeussler\Typo3FormConsent\Controller\ConsentController;
-use EliasHaeussler\Typo3FormConsent\Domain\Model\Consent;
-use EliasHaeussler\Typo3FormConsent\Form\Element\ConsentDataElement;
-use EliasHaeussler\Typo3FormConsent\Updates\MigrateConsentStateUpgradeWizard;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 use TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask;
@@ -53,7 +49,7 @@ final class Extension
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1576527415] = [
             'nodeName' => 'consentData',
             'priority' => 40,
-            'class' => ConsentDataElement::class,
+            'class' => Form\Element\ConsentDataElement::class,
         ];
     }
 
@@ -80,10 +76,10 @@ final class Extension
             self::NAME,
             'Consent',
             [
-                ConsentController::class => 'approve, dismiss',
+                Controller\ConsentController::class => 'approve, dismiss',
             ],
             [
-                ConsentController::class => 'approve, dismiss',
+                Controller\ConsentController::class => 'approve, dismiss',
             ]
         );
     }
@@ -95,8 +91,8 @@ final class Extension
      */
     public static function registerIcons(): void
     {
-        Icon::registerForPluginIdentifier('Consent');
-        Icon::registerForWidgetIdentifier('approvedConsents');
+        Configuration\Icon::registerForPluginIdentifier('Consent');
+        Configuration\Icon::registerForWidgetIdentifier('approvedConsents');
     }
 
     /**
@@ -110,7 +106,7 @@ final class Extension
             return;
         }
 
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][TableGarbageCollectionTask::class]['options']['tables'][Consent::TABLE_NAME] = [
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][TableGarbageCollectionTask::class]['options']['tables'][Domain\Model\Consent::TABLE_NAME] = [
             'expireField' => 'valid_until',
         ];
     }
@@ -122,7 +118,7 @@ final class Extension
      */
     public static function registerUpgradeWizards(): void
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][MigrateConsentStateUpgradeWizard::IDENTIFIER]
-            = MigrateConsentStateUpgradeWizard::class;
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][Updates\MigrateConsentStateUpgradeWizard::IDENTIFIER]
+            = Updates\MigrateConsentStateUpgradeWizard::class;
     }
 }

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -20,7 +20,7 @@
  */
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-    \EliasHaeussler\Typo3FormConsent\Configuration\Extension::KEY,
+    \EliasHaeussler\Typo3FormConsent\Extension::KEY,
     'Configuration/TypoScript',
     'Basic TypoScript for EXT:form_consent'
 );

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -20,7 +20,7 @@
  */
 
 \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin(
-    \EliasHaeussler\Typo3FormConsent\Configuration\Extension::NAME,
+    \EliasHaeussler\Typo3FormConsent\Extension::NAME,
     'Consent',
     \EliasHaeussler\Typo3FormConsent\Configuration\Localization::forPlugin('Consent')
 );

--- a/Tests/Functional/Configuration/ConfigurationTest.php
+++ b/Tests/Functional/Configuration/ConfigurationTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Configuration;
 
 use EliasHaeussler\Typo3FormConsent\Configuration\Configuration;
-use EliasHaeussler\Typo3FormConsent\Configuration\Extension;
+use EliasHaeussler\Typo3FormConsent\Extension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -19,9 +19,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-\EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerFormEngineNode();
-\EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerPageTsConfig();
-\EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerPlugin();
-\EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerIcons();
-\EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerGarbageCollectionTask();
-\EliasHaeussler\Typo3FormConsent\Configuration\Extension::registerUpgradeWizards();
+\EliasHaeussler\Typo3FormConsent\Extension::registerFormEngineNode();
+\EliasHaeussler\Typo3FormConsent\Extension::registerPageTsConfig();
+\EliasHaeussler\Typo3FormConsent\Extension::registerPlugin();
+\EliasHaeussler\Typo3FormConsent\Extension::registerIcons();
+\EliasHaeussler\Typo3FormConsent\Extension::registerGarbageCollectionTask();
+\EliasHaeussler\Typo3FormConsent\Extension::registerUpgradeWizards();

--- a/rector.php
+++ b/rector.php
@@ -49,7 +49,7 @@ return static function (RectorConfig $rectorConfig): void {
         ->withSymfony()
         ->withTYPO3()
         ->skip(AnnotationToAttributeRector::class, [
-            __DIR__ . '/Classes/Configuration/Extension.php',
+            __DIR__ . '/Classes/Extension.php',
             __DIR__ . '/Classes/Updates/MigrateConsentStateUpgradeWizard.php',
         ])
         ->skip(ClassPropertyAssignToConstructorPromotionRector::class, [


### PR DESCRIPTION
The `Extension` class is now located in the root namespace of the extension.