### PR TITLE
[!!!][TASK] Use DI in `Configuration` class

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -26,8 +26,6 @@ namespace EliasHaeussler\Typo3FormConsent\Configuration;
 use EliasHaeussler\Typo3FormConsent\Extension;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Exception;
-use TYPO3\CMS\Core\Utility\ArrayUtility;
-use TYPO3\CMS\Core\Utility\Exception\MissingArrayPathException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -38,42 +36,26 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 final class Configuration
 {
-    /**
-     * @var array<string, mixed>|null
-     */
-    private static ?array $configuration = null;
+    public function __construct(
+        private readonly ExtensionConfiguration $configuration,
+    ) {
+    }
 
     /**
      * @return list<string>
      */
-    public static function getExcludedElementsFromPersistence(): array
+    public function getExcludedElementsFromPersistence(): array
     {
-        $configurationValue = self::get('persistence/excludedElements');
-
-        if (!\is_string($configurationValue)) {
-            return [];
-        }
-
-        return GeneralUtility::trimExplode(',', $configurationValue, true);
-    }
-
-    /**
-     * @return mixed|null
-     */
-    private static function get(string $path)
-    {
-        if (self::$configuration === null) {
-            try {
-                self::$configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get(Extension::KEY);
-            } catch (Exception) {
-                self::$configuration = [];
-            }
-        }
-
         try {
-            return ArrayUtility::getValueByPath(self::$configuration, $path);
-        } catch (MissingArrayPathException) {
-            return null;
+            $configurationValue = $this->configuration->get(Extension::KEY, 'persistence/excludedElements');
+
+            if (!\is_string($configurationValue)) {
+                return [];
+            }
+
+            return GeneralUtility::trimExplode(',', $configurationValue, true);
+        } catch (Exception) {
+            return [];
         }
     }
 }

--- a/Classes/Type/Transformer/FormValuesTypeTransformer.php
+++ b/Classes/Type/Transformer/FormValuesTypeTransformer.php
@@ -37,6 +37,11 @@ use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
  */
 final class FormValuesTypeTransformer implements TypeTransformerInterface
 {
+    public function __construct(
+        private readonly Configuration $configuration,
+    ) {
+    }
+
     /**
      * @return JsonType<string, mixed>
      * @throws \JsonException
@@ -77,7 +82,7 @@ final class FormValuesTypeTransformer implements TypeTransformerInterface
 
     private function isElementExcluded(string $elementIdentifier, FormRuntime $formRuntime): bool
     {
-        $excludedElements = Configuration::getExcludedElementsFromPersistence();
+        $excludedElements = $this->configuration->getExcludedElementsFromPersistence();
         $element = $formRuntime->getFormDefinition()->getElementByIdentifier($elementIdentifier);
 
         return $element !== null && \in_array($element->getType(), $excludedElements, true);

--- a/Tests/Functional/Configuration/ConfigurationTest.php
+++ b/Tests/Functional/Configuration/ConfigurationTest.php
@@ -28,7 +28,6 @@ use EliasHaeussler\Typo3FormConsent\Extension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -43,11 +42,14 @@ final class ConfigurationTest extends FunctionalTestCase
     protected bool $initializeDatabase = false;
 
     protected ExtensionConfiguration $extensionConfiguration;
+    protected Configuration $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class);
+
+        $this->extensionConfiguration = $this->get(ExtensionConfiguration::class);
+        $this->subject = new Configuration($this->extensionConfiguration);
     }
 
     #[Test]
@@ -55,7 +57,7 @@ final class ConfigurationTest extends FunctionalTestCase
     {
         $this->extensionConfiguration->set(Extension::KEY, []);
 
-        self::assertSame([], Configuration::getExcludedElementsFromPersistence());
+        self::assertSame([], $this->subject->getExcludedElementsFromPersistence());
     }
 
     #[Test]
@@ -63,7 +65,7 @@ final class ConfigurationTest extends FunctionalTestCase
     {
         $this->extensionConfiguration->set(Extension::KEY);
 
-        self::assertSame([], Configuration::getExcludedElementsFromPersistence());
+        self::assertSame([], $this->subject->getExcludedElementsFromPersistence());
     }
 
     #[Test]
@@ -81,16 +83,6 @@ final class ConfigurationTest extends FunctionalTestCase
             'ContentElement',
         ];
 
-        self::assertSame($expected, Configuration::getExcludedElementsFromPersistence());
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $reflectionClass = new \ReflectionClass(Configuration::class);
-        $reflectionProperty = $reflectionClass->getProperty('configuration');
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue(null);
+        self::assertSame($expected, $this->subject->getExcludedElementsFromPersistence());
     }
 }

--- a/Tests/Functional/Type/Transformer/FormValuesTypeTransformerTest.php
+++ b/Tests/Functional/Type/Transformer/FormValuesTypeTransformerTest.php
@@ -56,7 +56,7 @@ final class FormValuesTypeTransformerTest extends FunctionalTestCase
     {
         parent::setUp();
 
-        $this->subject = new FormValuesTypeTransformer();
+        $this->subject = $this->get(FormValuesTypeTransformer::class);
         $this->formRuntime = $this->get(FormRuntime::class);
     }
 


### PR DESCRIPTION
This PR rewrites the `Configuration` class to use dependency injection. As a result, static methods must now be called on object level and consumers must inject the `Configuration` class properly.