### PR TITLE
[!!!][TASK] Drop TypeTransformerInterface::getName()

### DIFF
--- a/Classes/Type/Transformer/FormRequestTypeTransformer.php
+++ b/Classes/Type/Transformer/FormRequestTypeTransformer.php
@@ -94,9 +94,4 @@ final class FormRequestTypeTransformer implements TypeTransformerInterface
             ],
         ];
     }
-
-    public static function getName(): string
-    {
-        return 'formRequest';
-    }
 }

--- a/Classes/Type/Transformer/FormValuesTypeTransformer.php
+++ b/Classes/Type/Transformer/FormValuesTypeTransformer.php
@@ -25,6 +25,8 @@ namespace EliasHaeussler\Typo3FormConsent\Type\Transformer;
 
 use EliasHaeussler\Typo3FormConsent\Configuration\Configuration;
 use EliasHaeussler\Typo3FormConsent\Type\JsonType;
+use InvalidArgumentException;
+use JsonException;
 use TYPO3\CMS\Core\Resource\FileReference as CoreFileReference;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference as ExtbaseFileReference;
 use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
@@ -44,12 +46,12 @@ final class FormValuesTypeTransformer implements TypeTransformerInterface
 
     /**
      * @return JsonType<string, mixed>
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function transform(FormRuntime $formRuntime = null): JsonType
     {
         if ($formRuntime === null) {
-            throw new \InvalidArgumentException('Expected a valid FormRuntime object, NULL given.', 1646044591);
+            throw new InvalidArgumentException('Expected a valid FormRuntime object, NULL given.', 1646044591);
         }
 
         // Early return if form state is not available
@@ -86,10 +88,5 @@ final class FormValuesTypeTransformer implements TypeTransformerInterface
         $element = $formRuntime->getFormDefinition()->getElementByIdentifier($elementIdentifier);
 
         return $element !== null && \in_array($element->getType(), $excludedElements, true);
-    }
-
-    public static function getName(): string
-    {
-        return 'formValues';
     }
 }

--- a/Classes/Type/Transformer/TypeTransformerInterface.php
+++ b/Classes/Type/Transformer/TypeTransformerInterface.php
@@ -34,6 +34,4 @@ use EliasHaeussler\Typo3FormConsent\Type\JsonType;
 interface TypeTransformerInterface
 {
     public function transform(): JsonType;
-
-    public static function getName(): string;
 }


### PR DESCRIPTION
As a follow-up to #119, this PR drops the `TypeTransformerInterface::getName()` from said interface and its implementations.