### PR TITLE
[!!!][TASK] Rename TypeTransformerInterface to TypeTransformer

### DIFF
--- a/Classes/Type/Transformer/FormRequestTypeTransformer.php
+++ b/Classes/Type/Transformer/FormRequestTypeTransformer.php
@@ -37,7 +37,7 @@ use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
-final class FormRequestTypeTransformer implements TypeTransformerInterface
+final class FormRequestTypeTransformer implements TypeTransformer
 {
     public function __construct(
         private readonly HashService $hashService,

--- a/Classes/Type/Transformer/FormValuesTypeTransformer.php
+++ b/Classes/Type/Transformer/FormValuesTypeTransformer.php
@@ -36,7 +36,7 @@ use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
-final class FormValuesTypeTransformer implements TypeTransformerInterface
+final class FormValuesTypeTransformer implements TypeTransformer
 {
     public function __construct(
         private readonly Configuration $configuration,

--- a/Classes/Type/Transformer/TypeTransformer.php
+++ b/Classes/Type/Transformer/TypeTransformer.php
@@ -27,12 +27,12 @@ use EliasHaeussler\Typo3FormConsent\Type\JsonType;
 use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 
 /**
- * TypeTransformerInterface
+ * TypeTransformer
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
-interface TypeTransformerInterface
+interface TypeTransformer
 {
     public function transform(FormRuntime $formRuntime): JsonType;
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -22,9 +22,9 @@ parameters:
 			path: Classes/Domain/Finishers/FinisherOptions.php
 
 		-
-			message: "#^Method EliasHaeussler\\\\Typo3FormConsent\\\\Type\\\\Transformer\\\\TypeTransformerInterface\\:\\:transform\\(\\) return type with generic class EliasHaeussler\\\\Typo3FormConsent\\\\Type\\\\JsonType does not specify its types\\: TKey, TValue$#"
+			message: "#^Method EliasHaeussler\\\\Typo3FormConsent\\\\Type\\\\Transformer\\\\TypeTransformer\\:\\:transform\\(\\) return type with generic class EliasHaeussler\\\\Typo3FormConsent\\\\Type\\\\JsonType does not specify its types\\: TKey, TValue$#"
 			count: 1
-			path: Classes/Type/Transformer/TypeTransformerInterface.php
+			path: Classes/Type/Transformer/TypeTransformer.php
 
 		-
 			message: """


### PR DESCRIPTION
This PR removes the `Interface` suffix from `TypeTransformerInterface`.