### PR TITLE
[BUGFIX] Stabilize WebDriver capabilities by using `--no-sandbox`

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -15,7 +15,7 @@ suites:
             capabilities:
               acceptInsecureCerts: true
               chromeOptions:
-                args: ['--disable-dev-shm-usage']
+                args: ['--disable-dev-shm-usage', '--no-sandbox']
         - Db:
             dsn: 'mysql:host=db;dbname=db'
             user: 'root'


### PR DESCRIPTION
This PR adds the `--no-sandbox` chrome option to stabilize acceptance tests made with the `WebDriver` module, as suggested [here](https://stackoverflow.com/a/53970825).