### PR TITLE
[BUGFIX] Assure plugin namespace in original request parameters

### DIFF
--- a/Classes/Type/Transformer/FormRequestTypeTransformer.php
+++ b/Classes/Type/Transformer/FormRequestTypeTransformer.php
@@ -48,6 +48,7 @@ final class FormRequestTypeTransformer implements TypeTransformer
     public function transform(Form\Domain\Runtime\FormRuntime $formRuntime): Type\JsonType
     {
         $request = $formRuntime->getRequest();
+        $pluginNamespace = strtolower('tx_' . $request->getControllerExtensionName() . '_' . $request->getPluginName());
 
         // Handle submitted form values
         $requestParameters = [];
@@ -63,6 +64,14 @@ final class FormRequestTypeTransformer implements TypeTransformer
                 $value = $this->transformUploadedFile($file);
             }
         });
+
+        // Prepend plugin namespace to uploaded files array if not exists
+        // This is necessary since TYPO3 12.0, see https://github.com/typo3/typo3/commit/02198ea257b9f03f910b3b120392ab63fe792a8b
+        if (!isset($uploadedFiles[$pluginNamespace])) {
+            $uploadedFiles = [
+                $pluginNamespace => $uploadedFiles,
+            ];
+        }
 
         Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($requestParameters, $uploadedFiles);
 

--- a/Tests/Acceptance/Frontend/Domain/Finishers/ConsentFinisherCest.php
+++ b/Tests/Acceptance/Frontend/Domain/Finishers/ConsentFinisherCest.php
@@ -133,6 +133,31 @@ final class ConsentFinisherCest
         $I->assertQueryParameterEquals('user@example.com', $dismissUrl, 'tx_formconsent_consent/email');
     }
 
+    public function canSubmitFormAndStoreUploadedFiles(Tests\Acceptance\Support\AcceptanceTester $I): void
+    {
+        $I->fillAndSubmitForm(Tests\Acceptance\Support\Helper\Form::EMAIL_AFTER_APPROVE, true);
+
+        $I->fetchEmails();
+        $I->accessInboxFor('user@example.com');
+        $I->openNextUnreadEmail();
+
+        $I->seeUrlsInEmailBody(2);
+
+        $approveUrl = $I->grabUrlFromEmailBody(0);
+
+        $I->amOnPage($approveUrl);
+
+        $I->fetchEmails();
+        $I->accessInboxFor('admin@example.com');
+        $I->openNextUnreadEmail();
+
+        $I->haveNumberOfAttachmentsInOpenedEmail(1);
+
+        $I->openNextAttachmentInOpenedEmail();
+
+        $I->seeInFilenameOfOpenedAttachment('dummy.png');
+    }
+
     public function canSubmitFormWithCustomSender(Tests\Acceptance\Support\AcceptanceTester $I): void
     {
         $I->fillAndSubmitForm(Tests\Acceptance\Support\Helper\Form::V2);


### PR DESCRIPTION
This PR fixes an issue where the plugin namespace of EXT:form (`tx_form_formframework`) was not prepended to the uploaded files stored in original request parameters. This bug happened since TYPO3 12.0.0, respectively typo3/typo3@02198ea257b9f03f910b3b120392ab63fe792a8b.

Resolves: #138