### PR TITLE
[BUGFIX] Assure XDEBUG_MODE is set when running tests with coverage

### DIFF
--- a/.ddev/commands/web/init-typo3
+++ b/.ddev/commands/web/init-typo3
@@ -20,7 +20,7 @@ readonly fixturePath="/var/www/html/Tests/Acceptance/Data/Fixtures"
 readonly installationStepsPath="/var/www/html/Tests/Build/Installation/install-steps.yaml"
 
 typo3Binary="/var/www/html/.Build/bin/typo3"
-typo3Version="$($typo3Binary --version | awk '{print $3}')"
+typo3Version="$($typo3Binary --version --no-ansi | grep ^TYPO3 | awk '{print $3}')"
 typo3Version="${typo3Version%%.*}"
 
 # Use different console binary on TYPO3 v11

--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,7 @@
 			"codecept run --steps"
 		],
 		"test:coverage": [
+			"@putenv XDEBUG_MODE=coverage",
 			"@test:coverage:acceptance",
 			"@test:coverage:functional",
 			"@test:coverage:unit",


### PR DESCRIPTION
This PR fixes a bug with latest xdebug version where a globally configured `XDEBUG_MODE` is not properly respected. It can be reverted once a dedicated xdebug release is pushed and included in DDEV.