### PR TITLE
[TASK] Remove explicit dependency to "nikic/php-parser"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
 		"helmich/typo3-typoscript-lint": "^3.0",
 		"jangregor/phpstan-prophecy": "^1.0",
 		"koehnlein/codeception-email-mailpit": "^0.3.0",
-		"nikic/php-parser": "^4.12",
 		"phpstan/extension-installer": "^1.3",
 		"phpstan/phpstan-phpunit": "^1.0",
 		"phpunit/phpcov": "^9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4693b5651eb6aa4e7acc270e53131d68",
+    "content-hash": "816b2471a45efe894515145fbfcdf17d",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
The dependency to `nikic/php-parser` was added in an earlier stage to assure compatibility with lowest version constraints. However, it is no longer necessary to define it, therefore it's now dropped.