### PR TITLE
[!!!][FEATURE] Provide FinisherContext in ModifyConsentEvent

### DIFF
--- a/Classes/Domain/Factory/ConsentFactory.php
+++ b/Classes/Domain/Factory/ConsentFactory.php
@@ -52,8 +52,9 @@ final class ConsentFactory
 
     public function createFromForm(
         Domain\Finishers\FinisherOptions $finisherOptions,
-        Form\Domain\Runtime\FormRuntime $formRuntime,
+        Form\Domain\Finishers\FinisherContext $finisherContext,
     ): Domain\Model\Consent {
+        $formRuntime = $finisherContext->getFormRuntime();
         $submitDate = $this->getSubmitDate();
         $approvalPeriod = $finisherOptions->getApprovalPeriod();
 
@@ -75,7 +76,7 @@ final class ConsentFactory
         $consent->setValidationHash($this->hashService->generate($consent));
 
         // Dispatch ModifyConsent event
-        $this->eventDispatcher->dispatch(new Event\ModifyConsentEvent($consent, $formRuntime));
+        $this->eventDispatcher->dispatch(new Event\ModifyConsentEvent($consent, $finisherContext));
 
         // Re-generate validation hash if consent has changed in the meantime
         if (!$this->hashService->isValid($consent)) {

--- a/Classes/Domain/Finishers/ConsentFinisher.php
+++ b/Classes/Domain/Finishers/ConsentFinisher.php
@@ -73,7 +73,7 @@ final class ConsentFinisher extends Form\Domain\Finishers\AbstractFinisher
         $finisherOptions = new FinisherOptions(fn(string $optionName) => $this->parseOption($optionName));
 
         // Create consent
-        $consent = $this->consentFactory->createFromForm($finisherOptions, $formRuntime);
+        $consent = $this->consentFactory->createFromForm($finisherOptions, $this->finisherContext);
 
         // Persist consent
         $this->persistenceManager->add($consent);

--- a/Classes/Event/ModifyConsentEvent.php
+++ b/Classes/Event/ModifyConsentEvent.php
@@ -36,7 +36,7 @@ final class ModifyConsentEvent
 {
     public function __construct(
         private readonly Domain\Model\Consent $consent,
-        private readonly Form\Domain\Runtime\FormRuntime $formRuntime,
+        private readonly Form\Domain\Finishers\FinisherContext $finisherContext,
     ) {}
 
     public function getConsent(): Domain\Model\Consent
@@ -44,8 +44,8 @@ final class ModifyConsentEvent
         return $this->consent;
     }
 
-    public function getFormRuntime(): Form\Domain\Runtime\FormRuntime
+    public function getFinisherContext(): Form\Domain\Finishers\FinisherContext
     {
-        return $this->formRuntime;
+        return $this->finisherContext;
     }
 }

--- a/Documentation/DeveloperCorner/ConsentFactory.rst
+++ b/Documentation/DeveloperCorner/ConsentFactory.rst
@@ -17,7 +17,7 @@ dedicated consent factory is provided.
 
     Factory class to create new consents from a given form.
 
-    ..  php:method:: createFromForm($finisherOptions, $formRuntime)
+    ..  php:method:: createFromForm($finisherOptions, $finisherContext)
 
         Create a new form consent from the given form, derived from the
         given finisher options.
@@ -28,7 +28,7 @@ dedicated consent factory is provided.
             :ref:`modify-consent-event`.
 
         :param EliasHaeussler\\Typo3FormConsent\\Domain\\Finishers\\FinisherOptions $finisherOptions: Consent finisher options of the current form
-        :param TYPO3\\CMS\\Form\\Domain\\Runtime\\FormRuntime $formRuntime: The current form runtime
+        :param TYPO3\\CMS\\Form\\Domain\\Finishers\\FinisherContext $finisherContext: The current finisher context
         :returntype: EliasHaeussler\\Typo3FormConsent\\Domain\\Model\\Consent
 
 ..  seealso::

--- a/Documentation/Migration/Index.rst
+++ b/Documentation/Migration/Index.rst
@@ -9,6 +9,23 @@ Migration
 This page lists all notable changes and required migrations when
 upgrading to a new major version of this extension.
 
+..  _version-2.0.0:
+
+Version 2.0.0
+=============
+
+Finisher context in event
+-------------------------
+
+-   :php:class:`EliasHaeussler\\Typo3FormConsent\\Event\\ModifyConsentEvent` no longer
+    explicitly provides the current :php:class:`TYPO3\\CMS\\Form\\Domain\\Runtime\\FormRuntime`
+    instance via the :php:`getFormRuntime()` method. Use :php:`getFinisherContext()->getFormRuntime()`
+    instead.
+-   :php:meth:`EliasHaeussler\\Typo3FormConsent\\Domain\\Factory\\ConsentFactory::createFromForm`
+    no longer expects a :php:class:`TYPO3\\CMS\\Form\\Domain\\Runtime\\FormRuntime`
+    as second parameter. Pass the current :php:class:`TYPO3\\CMS\\Form\\Domain\\Finishers\\FinisherContext`
+    instead.
+
 ..  _version-1.0.0:
 
 Version 1.0.0

--- a/Tests/Unit/Event/ModifyConsentEventTest.php
+++ b/Tests/Unit/Event/ModifyConsentEventTest.php
@@ -39,15 +39,15 @@ final class ModifyConsentEventTest extends TestingFramework\Core\Unit\UnitTestCa
 {
     protected Src\Event\ModifyConsentEvent $subject;
     protected Src\Domain\Model\Consent $consent;
-    protected Form\Domain\Runtime\FormRuntime $formRuntimeMock;
+    protected Form\Domain\Finishers\FinisherContext $finisherContextMock;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->consent = new Src\Domain\Model\Consent();
-        $this->formRuntimeMock = $this->createMock(Form\Domain\Runtime\FormRuntime::class);
-        $this->subject = new Src\Event\ModifyConsentEvent($this->consent, $this->formRuntimeMock);
+        $this->finisherContextMock = $this->createMock(Form\Domain\Finishers\FinisherContext::class);
+        $this->subject = new Src\Event\ModifyConsentEvent($this->consent, $this->finisherContextMock);
     }
 
     #[Framework\Attributes\Test]
@@ -58,9 +58,9 @@ final class ModifyConsentEventTest extends TestingFramework\Core\Unit\UnitTestCa
     }
 
     #[Framework\Attributes\Test]
-    public function getFormRuntimeReturnsInitialFormRuntime(): void
+    public function getFinisherContextReturnsInitialFinisherContext(): void
     {
-        $expected = $this->formRuntimeMock;
-        self::assertSame($expected, $this->subject->getFormRuntime());
+        $expected = $this->finisherContextMock;
+        self::assertSame($expected, $this->subject->getFinisherContext());
     }
 }


### PR DESCRIPTION
This PR changes the components shipped by the `ModifyConsentEvent` to provide the overall `FinisherContext` instead of only the underlying `FormRuntime`. This, for example, allows to cancel current finisher execution by calling `$event->getFinisherContext()->cancel()`. Since the method signature of `ConsentFactory::createFromForm()` (which is public API) is modified, this change is considered breaking.