### PR TITLE
[FEATURE] Allow configuration of `Reply-To` recipients in consent mail

### DIFF
--- a/Classes/Domain/Finishers/ConsentFinisher.php
+++ b/Classes/Domain/Finishers/ConsentFinisher.php
@@ -99,6 +99,10 @@ final class ConsentFinisher extends Form\Domain\Finishers\AbstractFinisher
             $mail->from(new Mime\Address($senderAddress, $finisherOptions->getSenderName()));
         }
 
+        if ('' !== ($replyToAddress = $finisherOptions->getReplyToAddress())) {
+            $mail->replyTo(new Mime\Address($replyToAddress, $finisherOptions->getReplyToName()));
+        }
+
         // Provide form runtime as view helper variable to allow usage of
         // various form view helpers. This for example allows to list all
         // submitted form values using the <formvh:renderAllFormValues>

--- a/Classes/Domain/Finishers/FinisherOptions.php
+++ b/Classes/Domain/Finishers/FinisherOptions.php
@@ -57,6 +57,8 @@ final class FinisherOptions implements ArrayAccess
      *     recipientName?: string,
      *     senderAddress?: string,
      *     senderName?: string,
+     *     replyToAddress?: string,
+     *     replyToName?: string,
      *     approvalPeriod?: int,
      *     confirmationPid?: int,
      *     storagePid?: int,
@@ -172,6 +174,30 @@ final class FinisherOptions implements ArrayAccess
     {
         return $this->parsedOptions['senderName']
             ?? $this->parsedOptions['senderName'] = (string)($this->optionFetcher)('senderName');
+    }
+
+    public function getReplyToAddress(): string
+    {
+        if (isset($this->parsedOptions['replyToAddress'])) {
+            return $this->parsedOptions['replyToAddress'];
+        }
+
+        $replyToAddress = ($this->optionFetcher)('replyToAddress');
+
+        if (!\is_string($replyToAddress)) {
+            $this->throwException('replyToAddress.invalid', 1716797809);
+        }
+        if (trim($replyToAddress) !== '' && !Core\Utility\GeneralUtility::validEmail($replyToAddress)) {
+            $this->throwException('replyToAddress.invalid', 1716797811);
+        }
+
+        return $this->parsedOptions['replyToAddress'] = $replyToAddress;
+    }
+
+    public function getReplyToName(): string
+    {
+        return $this->parsedOptions['replyToName']
+            ?? $this->parsedOptions['replyToName'] = (string)($this->optionFetcher)('replyToName');
     }
 
     public function getApprovalPeriod(): int

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -60,6 +60,19 @@ TYPO3:
                           templateName: 'Inspector-TextEditor'
                           label: 'formEditor.elements.Form.finishers.Consent.editor.senderName.label'
                           propertyPath: 'options.senderName'
+                        620:
+                          identifier: 'replyToAddress'
+                          templateName: 'Inspector-TextEditor'
+                          label: 'formEditor.elements.Form.finishers.Consent.editor.replyToAddress.label'
+                          propertyPath: 'options.replyToAddress'
+                          enableFormelementSelectionButton: true
+                          propertyValidators:
+                            10: 'FormElementIdentifierWithinCurlyBracesInclusive'
+                        630:
+                          identifier: 'replyToName'
+                          templateName: 'Inspector-TextEditor'
+                          label: 'formEditor.elements.Form.finishers.Consent.editor.replyToName.label'
+                          propertyPath: 'options.replyToName'
                         700:
                           identifier: 'approvalPeriod'
                           templateName: 'Inspector-TextEditor'
@@ -109,6 +122,8 @@ TYPO3:
                 recipientName: ''
                 senderAddress: ''
                 senderName: ''
+                replyToAddress: ''
+                replyToName: ''
                 approvalPeriod: ''
                 showDismissLink: false
                 confirmationPid: ''
@@ -126,6 +141,8 @@ TYPO3:
                     recipientName: ''
                     senderAddress: ''
                     senderName: ''
+                    replyToAddress: ''
+                    replyToName: ''
                     # Approval period in seconds (default: 1 day)
                     approvalPeriod: '86400'
                     showDismissLink: false
@@ -158,6 +175,16 @@ TYPO3:
                       eval: 'trim'
                   senderName:
                     label: 'tt_content.finishersDefinition.Consent.senderName.label'
+                    config:
+                      type: 'input'
+                      eval: 'trim'
+                  replyToAddress:
+                    label: 'tt_content.finishersDefinition.Consent.replyToAddress.label'
+                    config:
+                      type: 'input'
+                      eval: 'trim'
+                  replyToName:
+                    label: 'tt_content.finishersDefinition.Consent.replyToName.label'
                     config:
                       type: 'input'
                       eval: 'trim'

--- a/Documentation/Configuration/FormFinisherConfiguration.rst
+++ b/Documentation/Configuration/FormFinisherConfiguration.rst
@@ -61,6 +61,34 @@ following options:
     Name of the consent mail sender. May contain placeholders to one or more
     existing form elements.
 
+..  _finisher-config-replyToAddress:
+
+..  confval:: replyToAddress
+
+    :Required: false
+    :type: string
+
+    ..  versionadded:: 2.2.0
+
+        `Feature #221 – Allow configuration of Reply-To recipients in consent mail <https://github.com/eliashaeussler/typo3-form-consent/pull/221>`__
+
+    Email address of the `Reply-To` mail recipient. Can be a placeholder to an
+    existing form element.
+
+..  _finisher-config-replyToName:
+
+..  confval:: replyToName
+
+    :Required: false
+    :type: string
+
+    ..  versionadded:: 2.2.0
+
+        `Feature #221 – Allow configuration of Reply-To recipients in consent mail <https://github.com/eliashaeussler/typo3-form-consent/pull/221>`__
+
+    Name of the `Reply-To` mail recipient. May contain placeholders to one or more
+    existing form elements.
+
 ..  _finisher-config-approvalPeriod:
 
 ..  confval:: approvalPeriod

--- a/Documentation/Usage/ConsentFinisher.rst
+++ b/Documentation/Usage/ConsentFinisher.rst
@@ -35,6 +35,8 @@ Example
           recipientName: '{first-name} {last-name}'
           senderAddress: ''
           senderName: ''
+          replyToAddress: ''
+          replyToName: ''
           approvalPeriod: '86400'
           showDismissLink: true
           confirmationPid: '277'

--- a/Resources/Private/Language/locallang_form.xlf
+++ b/Resources/Private/Language/locallang_form.xlf
@@ -25,6 +25,12 @@
 			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.senderName.label" resname="formEditor.elements.Form.finishers.Consent.editor.senderName.label">
 				<source>Sender name</source>
 			</trans-unit>
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.replyToAddress.label" resname="formEditor.elements.Form.finishers.Consent.editor.replyToAddress.label">
+				<source>Reply-To recipient e-mail address</source>
+			</trans-unit>
+			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.replyToName.label" resname="formEditor.elements.Form.finishers.Consent.editor.replyToName.label">
+				<source>Reply-To recipient name</source>
+			</trans-unit>
 			<trans-unit id="formEditor.elements.Form.finishers.Consent.editor.approvalPeriod.label" resname="formEditor.elements.Form.finishers.Consent.editor.approvalPeriod.label">
 				<source>Approval period</source>
 			</trans-unit>
@@ -72,6 +78,12 @@
 			<trans-unit id="tt_content.finishersDefinition.Consent.senderName.label" resname="tt_content.finishersDefinition.Consent.senderName.label">
 				<source>Sender name</source>
 			</trans-unit>
+			<trans-unit id="tt_content.finishersDefinition.Consent.replyToAddress.label" resname="tt_content.finishersDefinition.Consent.replyToAddress.label">
+				<source>Reply-To recipient e-mail address</source>
+			</trans-unit>
+			<trans-unit id="tt_content.finishersDefinition.Consent.replyToName.label" resname="tt_content.finishersDefinition.Consent.replyToName.label">
+				<source>Reply-To recipient name</source>
+			</trans-unit>
 			<trans-unit id="tt_content.finishersDefinition.Consent.approvalPeriod.label" resname="tt_content.finishersDefinition.Consent.approvalPeriod.label">
 				<source>Approval period</source>
 			</trans-unit>
@@ -93,6 +105,9 @@
 			</trans-unit>
 			<trans-unit id="validation.senderAddress.invalid" resname="validation.senderAddress.invalid">
 				<source>The finisher option "senderAddress" must contain a valid e-mail address.</source>
+			</trans-unit>
+			<trans-unit id="validation.replyToAddress.invalid" resname="validation.replyToAddress.invalid">
+				<source>The finisher option "replyToAddress" must contain a valid e-mail address.</source>
 			</trans-unit>
 			<trans-unit id="validation.approvalPeriod.invalid" resname="validation.approvalPeriod.invalid">
 				<source>The finisher option "approvalPeriod" must be zero or more seconds.</source>

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-confirmation-approve-variant.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-confirmation-approve-variant.form.yaml
@@ -23,6 +23,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-confirmation-dismiss-variant.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-confirmation-dismiss-variant.form.yaml
@@ -23,6 +23,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-email-approve-variant.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-email-approve-variant.form.yaml
@@ -32,6 +32,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-invalid-closure-approve-variant.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-invalid-closure-approve-variant.form.yaml
@@ -22,6 +22,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-invalid-closure-dismiss-variant.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-invalid-closure-dismiss-variant.form.yaml
@@ -22,6 +22,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-invalid.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-invalid.form.yaml
@@ -13,6 +13,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-redirect-approve-dismiss-variant.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-redirect-approve-dismiss-variant.form.yaml
@@ -32,6 +32,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-redirect-approve-variant.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-redirect-approve-variant.form.yaml
@@ -23,6 +23,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-redirect-dismiss-variant.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-redirect-dismiss-variant.form.yaml
@@ -23,6 +23,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-v2.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact-v2.form.yaml
@@ -13,6 +13,8 @@ finishers:
       recipientName: ''
       senderAddress: 'sender@example.com'
       senderName: ''
+      replyToAddress: 'reply-to@example.com'
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Data/Fileadmin/form_definitions/contact.form.yaml
+++ b/Tests/Acceptance/Data/Fileadmin/form_definitions/contact.form.yaml
@@ -13,6 +13,8 @@ finishers:
       recipientName: ''
       senderAddress: ''
       senderName: ''
+      replyToAddress: ''
+      replyToName: ''
       approvalPeriod: '86400'
       showDismissLink: true
       confirmationPid: '2'

--- a/Tests/Acceptance/Frontend/Domain/Finishers/ConsentFinisherCest.php
+++ b/Tests/Acceptance/Frontend/Domain/Finishers/ConsentFinisherCest.php
@@ -158,7 +158,7 @@ final class ConsentFinisherCest
         $I->seeInFilenameOfOpenedAttachment('dummy.png');
     }
 
-    public function canSubmitFormWithCustomSender(Tests\Acceptance\Support\AcceptanceTester $I): void
+    public function canSubmitFormWithCustomSenderAndReplyToRecipient(Tests\Acceptance\Support\AcceptanceTester $I): void
     {
         $I->fillAndSubmitForm(Tests\Acceptance\Support\Helper\Form::V2);
 
@@ -167,6 +167,7 @@ final class ConsentFinisherCest
         $I->openNextUnreadEmail();
 
         $I->seeInOpenedEmailSender('sender@example.com');
+        $I->seeInOpenedEmailReplyTo('reply-to@example.com');
     }
 
     public function cannotSubmitInvalidForm(Tests\Acceptance\Support\AcceptanceTester $I): void

--- a/Tests/Functional/Domain/Finishers/ConsentFinisherTest.php
+++ b/Tests/Functional/Domain/Finishers/ConsentFinisherTest.php
@@ -89,6 +89,8 @@ final class ConsentFinisherTest extends TestingFramework\Core\Functional\Functio
             'recipientName' => '',
             'senderAddress' => '',
             'senderName' => '',
+            'replyToAddress' => '',
+            'replyToName' => '',
             'approvalPeriod' => 86400,
             'showDismissLink' => true,
             'confirmationPid' => 1,

--- a/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
+++ b/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
@@ -234,6 +234,54 @@ final class FinisherOptionsTest extends TestingFramework\Core\Functional\Functio
     }
 
     #[Framework\Attributes\Test]
+    public function getReplyToAddressReturnsAlreadyParsedReplyToAddress(): void
+    {
+        $this->options['replyToAddress'] = 'foo@baz.de';
+
+        self::assertSame('foo@baz.de', $this->subject->getReplyToAddress());
+
+        $this->options = [];
+
+        self::assertSame('foo@baz.de', $this->subject->getReplyToAddress());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReplyToAddressThrowsExceptionIfFetchedReplyToAddressIsNotAString(): void
+    {
+        $this->options['replyToAddress'] = null;
+
+        $this->expectException(Form\Domain\Finishers\Exception\FinisherException::class);
+        $this->expectExceptionCode(1716797809);
+        $this->expectExceptionMessage('The finisher option "replyToAddress" must contain a valid e-mail address.');
+
+        $this->subject->getReplyToAddress();
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReplyToAddressThrowsExceptionIfFetchedReplyToAddressIsNotEmptyAndInvalid(): void
+    {
+        $this->options['replyToAddress'] = 'foo';
+
+        $this->expectException(Form\Domain\Finishers\Exception\FinisherException::class);
+        $this->expectExceptionCode(1716797811);
+        $this->expectExceptionMessage('The finisher option "replyToAddress" must contain a valid e-mail address.');
+
+        $this->subject->getReplyToAddress();
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReplyToNameReturnsReplyToNameAndStoresTheParsedResult(): void
+    {
+        $this->options['replyToName'] = 'foo';
+
+        self::assertSame('foo', $this->subject->getReplyToName());
+
+        $this->options = [];
+
+        self::assertSame('foo', $this->subject->getReplyToName());
+    }
+
+    #[Framework\Attributes\Test]
     public function getApprovalPeriodReturnsAlreadyParsedApprovalPeriod(): void
     {
         $this->options['approvalPeriod'] = 86400;


### PR DESCRIPTION
This PR adds support for a `Reply-To` recipient in consent mail.