### PR TITLE
[TASK] Avoid useless switch for eval "required" in TYPO3 < v12

### DIFF
--- a/Configuration/TCA/tx_formconsent_domain_model_consent.php
+++ b/Configuration/TCA/tx_formconsent_domain_model_consent.php
@@ -74,10 +74,9 @@ return [
                 ? [
                     'type' => 'input',
                     'renderType' => 'inputDateTime',
-                    'eval' => $evalRequired('datetime,int'),
+                    'eval' => 'datetime,int,required',
                     'default' => 0,
                     'readOnly' => true,
-                    'required' => true,
                 ]
                 : [
                     'type' => 'datetime',


### PR DESCRIPTION
This PR removes a useless switch for `eval` with `required` in a table column configuration for TYPO3 < v12.