### PR TITLE
[FEATURE] Add support for site sets (TYPO3 >= v13.1)

### DIFF
--- a/Configuration/Sets/FormConsent/config.yaml
+++ b/Configuration/Sets/FormConsent/config.yaml
@@ -1,0 +1,4 @@
+name: eliashaeussler/typo3-form-consent
+label: Form Consent
+dependencies:
+  - typo3/form

--- a/Configuration/Sets/FormConsent/constants.typoscript
+++ b/Configuration/Sets/FormConsent/constants.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:form_consent/Configuration/TypoScript/constants.typoscript'

--- a/Configuration/Sets/FormConsent/settings.definitions.yaml
+++ b/Configuration/Sets/FormConsent/settings.definitions.yaml
@@ -1,0 +1,17 @@
+settings:
+  plugin.tx_formconsent.view.templateRootPath:
+    default: ''
+    label: 'Path to template root (FE)'
+    type: string
+  plugin.tx_formconsent.view.partialRootPath:
+    default: ''
+    label: 'Path to template partials (FE)'
+    type: string
+  plugin.tx_formconsent.view.layoutRootPath:
+    default: ''
+    label: 'Path to template layouts (FE)'
+    type: string
+  plugin.tx_formconsent.persistence.storagePid:
+    default: 0
+    label: 'Default storage PID for consent data'
+    type: int

--- a/Configuration/Sets/FormConsent/setup.typoscript
+++ b/Configuration/Sets/FormConsent/setup.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:form_consent/Configuration/TypoScript/setup.typoscript'

--- a/Documentation/Configuration/FormFinisherConfiguration.rst
+++ b/Documentation/Configuration/FormFinisherConfiguration.rst
@@ -143,8 +143,10 @@ following options:
     ..  note::
 
         Set to :yaml:`0` to use the default storage PID configured in
-        TypoScript configuration :typoscript:`plugin.tx_formconsent.persistence.storagePid`.
-        See :ref:`typoscript-configuration` for more information.
+        site set setting :yaml:`plugin.tx_formconsent.persistence.storagePid`
+        or TypoScript configuration :typoscript:`plugin.tx_formconsent.persistence.storagePid`.
+        See :ref:`site-set-configuration` and :ref:`typoscript-configuration`
+        for more information.
 
 ..  _finisher-config-templateRootPaths:
 
@@ -159,7 +161,8 @@ following options:
     ..  note::
 
         Template root paths configured in form finishers take precedence over
-        the ones configured within :ref:`TypoScript <typoscript-configuration>`.
+        the ones configured within :ref:`site settings <site-set-configuration>`
+        and :ref:`TypoScript <typoscript-configuration>`.
 
 ..  _finisher-config-partialRootPaths:
 
@@ -174,7 +177,8 @@ following options:
     ..  note::
 
         Partial root paths configured in form finishers take precedence over
-        the ones configured within :ref:`TypoScript <typoscript-configuration>`.
+        the ones configured within :ref:`site settings <site-set-configuration>`
+        and :ref:`TypoScript <typoscript-configuration>`.
 
 ..  _finisher-config-layoutRootPaths:
 
@@ -189,4 +193,5 @@ following options:
     ..  note::
 
         Layout root paths configured in form finishers take precedence over
-        the ones configured within :ref:`TypoScript <typoscript-configuration>`.
+        the ones configured within :ref:`site settings <site-set-configuration>`
+        and :ref:`TypoScript <typoscript-configuration>`.

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -12,5 +12,6 @@ Learn what configuration options are available on the following pages:
     :maxdepth: 3
 
     FormFinisherConfiguration
+    SiteSetConfiguration
     TypoScriptConfiguration
     ExtensionConfiguration

--- a/Documentation/Configuration/SiteSetConfiguration.rst
+++ b/Documentation/Configuration/SiteSetConfiguration.rst
@@ -1,0 +1,89 @@
+..  include:: /Includes.rst.txt
+
+..  _site-set-configuration:
+
+=====================
+SiteSet configuration
+=====================
+
+..  versionadded:: 2.3.0
+
+    `Feature #259 – Add support for site sets (TYPO3 >= v13.1) <https://github.com/eliashaeussler/typo3-form-consent/pull/259>`__
+
+The extension ships with a :ref:`site set <t3coreapi:site-sets>` called
+:yaml:`eliashaeussler/typo3-form-consent`. It can be used as drop-in replacement
+for :ref:`TypoScript <typoscript-configuration>` in TYPO3 v13.1 or later.
+
+The following settings are available for the site set:
+
+..  _site-set-settings:
+
+Settings
+========
+
+..  _site-set-settings-view.templateRootPath:
+
+..  confval:: view.templateRootPath
+
+    :type: string
+    :Path: :yaml:`plugin.tx_formconsent`
+
+    Additional path to template root used in Frontend context. Within this
+    path, Fluid templates of the consent mail sent by the
+    :ref:`consent finisher <consent-finisher>` as well as templates of the
+    :ref:`validation plugin <validation-plugin>` can be overwritten.
+
+    ..  seealso::
+
+        Read more in the :ref:`official documentation <t3tsref:setup-plugin-view-templateRootPaths>`.
+
+..  _site-set-settings-view.partialRootPath:
+
+..  confval:: view.partialRootPath
+
+    :type: string
+    :Path: :yaml:`plugin.tx_formconsent`
+
+    Additional path to template partials used in Frontend context. Within this
+    path, Fluid partials of the consent mail sent by the
+    :ref:`consent finisher <consent-finisher>` as well as templates of the
+    :ref:`validation plugin <validation-plugin>` can be overwritten.
+
+    ..  seealso::
+
+        Read more in the :ref:`official documentation <t3tsref:setup-plugin-view-partialRootPaths>`.
+
+..  _site-set-settings-view.layoutRootPath:
+
+..  confval:: view.layoutRootPath
+
+    :type: string
+    :Path: :yaml:`plugin.tx_formconsent`
+
+    Additional path to template layouts used in Frontend context. Within this
+    path, Fluid layouts of the consent mail sent by the
+    :ref:`consent finisher <consent-finisher>` as well as templates of the
+    :ref:`validation plugin <validation-plugin>` can be overwritten.
+
+    ..  seealso::
+
+        Read more in the :ref:`official documentation <t3tsref:setup-plugin-view-layoutRootPaths>`.
+
+..  _site-set-settings-persistence.storagePid:
+
+..  confval:: persistence.storagePid
+
+    :type: integer
+    :Path: :yaml:`plugin.tx_formconsent`
+
+    Page ID where to store new consents created by the
+    :ref:`consent finisher <consent-finisher>`.
+
+    ..  note::
+
+        This configuration option can be overridden in each form configuration.
+        See :ref:`form-finisher-configuration` for more information.
+
+    ..  seealso::
+
+        Read more in the :ref:`official documentation <t3tsref:setup-plugin-persistence-storagePid>`.

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -82,8 +82,8 @@ compliance with the GDPR.
             ..  container:: card-body
 
                 Learn how to configure the extension in various ways.
-                This includes extension configuration, TypoScript
-                configuration and form finisher configuration.
+                This includes extension configuration, site sets,
+                TypoScript configuration and form finisher configuration.
 
     ..  container:: col-12 col-md-6 pl-0 pr-0 pr-md-3 pt-3 m-0
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -28,13 +28,14 @@ Require the extension via Composer (recommended):
 Or download it from the
 `TYPO3 extension repository <https://extensions.typo3.org/extension/form_consent>`__.
 
-..  _typoscript-setup:
+..  _initial-setup:
 
-TypoScript setup
-================
+Initial setup
+=============
 
-Once installed, make sure to include the TypoScript setup at
-:file:`EXT:form_consent/Configuration/TypoScript` in your root template.
+Once installed, make sure to add the site set :yaml:`eliashaeussler/typo3-form-consent`
+as dependency to your site (TYPO3 >= 13.1) or include the TypoScript setup
+at :file:`EXT:form_consent/Configuration/TypoScript` in your root template.
 
 ..  _version-matrix:
 

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -7,7 +7,8 @@ Usage
 =====
 
 This section describes how to properly use the extension. Before you
-start, make sure to :ref:`include the static TypoScript <typoscript-setup>`
+start, make sure to add the :ref:`site set <initial-setup>` as dependency
+to your site or :ref:`include the static TypoScript <initial-setup>`
 provided by the extension.
 
 ..  toctree::

--- a/Tests/Build/Configuration/sites/main/config.yaml
+++ b/Tests/Build/Configuration/sites/main/config.yaml
@@ -1,5 +1,7 @@
 base: 'https://typo3-ext-form-consent.ddev.site/'
-errorHandling: {  }
+dependencies:
+  - typo3/fluid-styled-content
+  - eliashaeussler/typo3-form-consent
 languages:
   -
     title: English
@@ -14,4 +16,4 @@ languages:
     direction: ltr
     flag: us
 rootPageId: 1
-routes: {  }
+websiteTitle: ''


### PR DESCRIPTION
This PR adds a new site set for use with TYPO3 >= 13.1.

TODO:

- [ ] AC tests with site set enabled
- [x] Documentation