### PR TITLE
[BUGFIX] Respect default storage pid if storage pid is not set in form

### DIFF
--- a/Classes/Domain/Finishers/FinisherOptions.php
+++ b/Classes/Domain/Finishers/FinisherOptions.php
@@ -241,7 +241,12 @@ final class FinisherOptions implements \ArrayAccess
 
         $storagePid = (int)($this->optionFetcher)('storagePid');
 
-        // Return if storage pid is not set since it is not a mandatory option
+        // Use default storage pid if storage pid is not defined in form
+        if ($storagePid === 0) {
+            $storagePid = $this->fetchDefaultStoragePid();
+        }
+
+        // Early return if storage pid is not set since it is not a mandatory option
         if ($storagePid === 0) {
             return $this->parsedOptions['storagePid'] = $storagePid;
         }
@@ -300,6 +305,18 @@ final class FinisherOptions implements \ArrayAccess
     public function offsetUnset($offset): void
     {
         throw Exception\NotAllowedException::forMethod(__METHOD__);
+    }
+
+    private function fetchDefaultStoragePid(): int
+    {
+        $configurationManager = Core\Utility\GeneralUtility::makeInstance(Extbase\Configuration\ConfigurationManagerInterface::class);
+        $configuration = $configurationManager->getConfiguration(
+            Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK,
+            Extension::NAME,
+            Extension::PLUGIN,
+        );
+
+        return (int)($configuration['persistence']['storagePid'] ?? 0);
     }
 
     private function getPageRepository(): Core\Domain\Repository\PageRepository

--- a/Classes/Extension.php
+++ b/Classes/Extension.php
@@ -38,6 +38,7 @@ final class Extension
 {
     public const KEY = 'form_consent';
     public const NAME = 'FormConsent';
+    public const PLUGIN = 'Consent';
 
     /**
      * Register additional FormEngine node.
@@ -80,7 +81,7 @@ final class Extension
     {
         Extbase\Utility\ExtensionUtility::configurePlugin(
             self::NAME,
-            'Consent',
+            self::PLUGIN,
             [
                 Controller\ConsentController::class => 'approve, dismiss',
             ],
@@ -97,7 +98,7 @@ final class Extension
      */
     public static function registerIcons(): void
     {
-        Configuration\Icon::registerForPluginIdentifier('Consent');
+        Configuration\Icon::registerForPluginIdentifier(self::PLUGIN);
         Configuration\Icon::registerForWidgetIdentifier('approvedConsents');
     }
 

--- a/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
+++ b/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Domain\Finishers;
 use EliasHaeussler\Typo3FormConsent as Src;
 use PHPUnit\Framework;
 use TYPO3\CMS\Core;
+use TYPO3\CMS\Extbase;
 use TYPO3\CMS\Fluid;
 use TYPO3\CMS\Form;
 use TYPO3\TestingFramework;
@@ -47,6 +48,10 @@ final class FinisherOptionsTest extends TestingFramework\Core\Functional\Functio
         'form_consent',
     ];
 
+    /**
+     * @var Framework\MockObject\MockObject&Extbase\Configuration\ConfigurationManagerInterface $configurationManager
+     */
+    protected Framework\MockObject\MockObject $configurationManager;
     protected Src\Domain\Finishers\FinisherOptions $subject;
 
     /**
@@ -58,7 +63,13 @@ final class FinisherOptionsTest extends TestingFramework\Core\Functional\Functio
     {
         parent::setUp();
 
+        $this->configurationManager = $this->createMock(Extbase\Configuration\ConfigurationManagerInterface::class);
         $this->subject = new Src\Domain\Finishers\FinisherOptions($this->fetchOption(...));
+
+        Core\Utility\GeneralUtility::setSingletonInstance(
+            Extbase\Configuration\ConfigurationManagerInterface::class,
+            $this->configurationManager,
+        );
 
         $this->importCSVDataSet(\dirname(__DIR__, 2) . '/Fixtures/be_users.csv');
         $this->importCSVDataSet(\dirname(__DIR__, 2) . '/Fixtures/pages.csv');
@@ -342,9 +353,29 @@ final class FinisherOptionsTest extends TestingFramework\Core\Functional\Functio
     }
 
     #[Framework\Attributes\Test]
+    public function getStoragePidReturnsDefaultStoragePidIfFetchedStoragePidIsZero(): void
+    {
+        $this->options['storagePid'] = 0;
+
+        $this->configurationManager->method('getConfiguration')->willReturn([
+            'persistence' => [
+                'storagePid' => '1',
+            ],
+        ]);
+
+        self::assertSame(1, $this->subject->getStoragePid());
+    }
+
+    #[Framework\Attributes\Test]
     public function getStoragePidReturnsZeroIfFetchedStoragePidIsZero(): void
     {
         $this->options['storagePid'] = 0;
+
+        $this->configurationManager->method('getConfiguration')->willReturn([
+            'persistence' => [
+                'storagePid' => '0',
+            ],
+        ]);
 
         self::assertSame(0, $this->subject->getStoragePid());
     }


### PR DESCRIPTION
It turned out that the default storage pid configured as TypoScript constant `plugin.tx_formconsent.persistence.storagePid` was never respected. This PR fixes this behavior and explicitly looks up this value if no storage pid is configured in a form.