### PR TITLE
Respect order of template/partial/layout root paths

### DIFF
--- a/Classes/Domain/Finishers/FinisherOptions.php
+++ b/Classes/Domain/Finishers/FinisherOptions.php
@@ -126,6 +126,10 @@ final class FinisherOptions implements \ArrayAccess
         $this->parsedOptions['templatePaths']->setPartialRootPaths($mergedTemplateConfiguration['partialRootPaths']);
         $this->parsedOptions['templatePaths']->setLayoutRootPaths($mergedTemplateConfiguration['layoutRootPaths']);
 
+        if (isset($mergedTemplateConfiguration['format'])) {
+            $this->parsedOptions['templatePaths']->setFormat($mergedTemplateConfiguration['format']);
+        }
+
         return $this->parsedOptions['templatePaths'];
     }
 

--- a/Classes/Domain/Finishers/FinisherOptions.php
+++ b/Classes/Domain/Finishers/FinisherOptions.php
@@ -121,6 +121,10 @@ final class FinisherOptions implements \ArrayAccess
             $finisherTemplateConfiguration
         );
 
+        ksort($mergedTemplateConfiguration['templateRootPaths']);
+        ksort($mergedTemplateConfiguration['partialRootPaths']);
+        ksort($mergedTemplateConfiguration['layoutRootPaths']);
+
         return $this->parsedOptions['templatePaths'] = Core\Utility\GeneralUtility::makeInstance(
             Fluid\View\TemplatePaths::class,
             $mergedTemplateConfiguration

--- a/Classes/Domain/Finishers/FinisherOptions.php
+++ b/Classes/Domain/Finishers/FinisherOptions.php
@@ -118,17 +118,15 @@ final class FinisherOptions implements \ArrayAccess
         $mergedTemplateConfiguration = array_replace_recursive(
             $defaultTemplateConfiguration,
             $typoScriptTemplateConfiguration,
-            $finisherTemplateConfiguration
+            $finisherTemplateConfiguration,
         );
 
-        ksort($mergedTemplateConfiguration['templateRootPaths']);
-        ksort($mergedTemplateConfiguration['partialRootPaths']);
-        ksort($mergedTemplateConfiguration['layoutRootPaths']);
+        $this->parsedOptions['templatePaths'] = Core\Utility\GeneralUtility::makeInstance(Fluid\View\TemplatePaths::class);
+        $this->parsedOptions['templatePaths']->setTemplateRootPaths($mergedTemplateConfiguration['templateRootPaths']);
+        $this->parsedOptions['templatePaths']->setPartialRootPaths($mergedTemplateConfiguration['partialRootPaths']);
+        $this->parsedOptions['templatePaths']->setLayoutRootPaths($mergedTemplateConfiguration['layoutRootPaths']);
 
-        return $this->parsedOptions['templatePaths'] = Core\Utility\GeneralUtility::makeInstance(
-            Fluid\View\TemplatePaths::class,
-            $mergedTemplateConfiguration
-        );
+        return $this->parsedOptions['templatePaths'];
     }
 
     public function getRecipientAddress(): string

--- a/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
+++ b/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
@@ -124,10 +124,20 @@ final class FinisherOptionsTest extends TestingFramework\Core\Functional\Functio
             ],
         ];
 
-        $templatePathsArray = $this->options;
-        $templatePathsArray['format'] = 'both';
-
-        $expected = new Fluid\View\TemplatePaths($templatePathsArray);
+        $expected = new Fluid\View\TemplatePaths();
+        $expected->setTemplateRootPaths([
+            0 => 'foo',
+            10 => 'baz',
+        ]);
+        $expected->setPartialRootPaths([
+            0 => 'foo',
+            10 => 'baz',
+        ]);
+        $expected->setLayoutRootPaths([
+            0 => 'foo',
+            10 => 'baz',
+        ]);
+        $expected->setFormat('both');
 
         self::assertEquals($expected, $this->subject->getTemplatePaths());
 


### PR DESCRIPTION
These paths are registered with with numeric indices which indicate the priority. The higher the number, the higher the priority of the path for lookup.

For TYPO3 before version 12 this priority must be implemented manually by sorting paths by their keys.

See https://github.com/TYPO3/typo3/blob/v12.4.20/typo3/sysext/form/Classes/Domain/Finishers/EmailFinisher.php#L172
And https://github.com/TYPO3/typo3/commit/c68090f2e802e363869dc3d2f79f2b51f3e5f8be