### PR TITLE
[BUGFIX] Assure global TypoScript can be loaded with site sets

### DIFF
--- a/Classes/Extension.php
+++ b/Classes/Extension.php
@@ -106,4 +106,22 @@ final class Extension
             'expireField' => 'valid_until',
         ];
     }
+
+    /**
+     * Register global TypoScript setup.
+     *
+     * FOR USE IN ext_localconf.php ONLY.
+     */
+    public static function registerTypoScript(): void
+    {
+        Core\Utility\ExtensionManagementUtility::addTypoScriptSetup('
+            module.tx_form {
+                settings {
+                    yamlConfigurations {
+                        1576524005 = EXT:form_consent/Configuration/Yaml/FormSetup.yaml
+                    }
+                }
+            }
+        ');
+    }
 }

--- a/Tests/CGL/typoscript-lint.yml
+++ b/Tests/CGL/typoscript-lint.yml
@@ -1,7 +1,6 @@
 paths:
   - ../../Configuration
   - ../../ext_conf_template.txt
-  - ../../ext_typoscript_*
 filePatterns:
   - "*.tsconfig"
   - "*.typoscript"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,3 +23,4 @@
 \EliasHaeussler\Typo3FormConsent\Extension::registerPageTsConfig();
 \EliasHaeussler\Typo3FormConsent\Extension::registerPlugin();
 \EliasHaeussler\Typo3FormConsent\Extension::registerGarbageCollectionTask();
+\EliasHaeussler\Typo3FormConsent\Extension::registerTypoScript();

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -1,7 +1,0 @@
-module.tx_form {
-  settings {
-    yamlConfigurations {
-      1576524005 = EXT:form_consent/Configuration/Yaml/FormSetup.yaml
-    }
-  }
-}


### PR DESCRIPTION
This PR moves global TypoScript configuration from `ext_typoscript_setup.typoscript` to `ext_localconf.php` which is required when using site sets.