### PR TITLE
[BUGFIX] Enable extensions of dependent site sets in functional tests

### DIFF
--- a/Tests/Functional/Domain/Finishers/ConsentFinisherTest.php
+++ b/Tests/Functional/Domain/Finishers/ConsentFinisherTest.php
@@ -42,6 +42,7 @@ use TYPO3\CMS\Frontend;
 final class ConsentFinisherTest extends Tests\Functional\ExtbaseRequestAwareFunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [
+        'fluid_styled_content',
         'form',
     ];
 

--- a/Tests/Functional/Domain/Repository/ConsentRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ConsentRepositoryTest.php
@@ -38,6 +38,7 @@ use TYPO3\CMS\Core;
 final class ConsentRepositoryTest extends Tests\Functional\ExtbaseRequestAwareFunctionalTestCase
 {
     protected array $coreExtensionsToLoad = [
+        'fluid_styled_content',
         'form',
     ];
 


### PR DESCRIPTION
The example site configuration used in functional tests defines dependencies to other sites sets. With recent implementations, an exception is thrown if these extensions are not active. Hence, we must enable them in the appropriate functional tests.