### PR TITLE
[TASK] Use `phpunit-attributes` package to skip a test

### DIFF
--- a/Tests/Unit/Compatibility/Migration/HmacHashMigrationTest.php
+++ b/Tests/Unit/Compatibility/Migration/HmacHashMigrationTest.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Compatibility\Migration;
 
+use EliasHaeussler\PHPUnitAttributes;
 use EliasHaeussler\Typo3FormConsent as Src;
 use PHPUnit\Framework;
-use TYPO3\CMS\Core;
 use TYPO3\TestingFramework;
 
 /**
@@ -35,6 +35,8 @@ use TYPO3\TestingFramework;
  * @license GPL-2.0-or-later
  */
 #[Framework\Attributes\CoversClass(Src\Compatibility\Migration\HmacHashMigration::class)]
+// @todo Remove once support for TYPO3 v12 is dropped
+#[PHPUnitAttributes\Attribute\RequiresPackage('typo3/cms-core', '>= 13')]
 final class HmacHashMigrationTest extends TestingFramework\Core\Unit\UnitTestCase
 {
     protected bool $resetSingletonInstances = true;
@@ -44,11 +46,6 @@ final class HmacHashMigrationTest extends TestingFramework\Core\Unit\UnitTestCas
     public function setUp(): void
     {
         parent::setUp();
-
-        // @todo Remove once support for TYPO3 v12 is dropped
-        if ((new Core\Information\Typo3Version())->getMajorVersion() < 13) {
-            self::markTestSkipped('Test can be executed on TYPO3 >= 13 only.');
-        }
 
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'e52bf8903ee05ddfa65107175fbf7c72fd57482f28733701585f11c04885cab5474f2811c442ba87f93e1a63db8c0443';
 

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 		"codeception/module-asserts": "^3.0",
 		"codeception/module-db": "^3.1",
 		"codeception/module-webdriver": "^4.0",
+		"eliashaeussler/phpunit-attributes": "^1.3",
 		"eliashaeussler/typo3-codeception-helper": "^1.2",
 		"eliashaeussler/typo3-form-consent-test-extension": "1.0.0",
 		"eliashaeussler/version-bumper": "^2.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a4acbf8a88498c847cc68d0ce5e402e",
+    "content-hash": "11ca5ffdfd594509454b5174e703c744",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6594,6 +6594,60 @@
                 }
             ],
             "time": "2024-11-26T16:23:11+00:00"
+        },
+        {
+            "name": "eliashaeussler/phpunit-attributes",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/eliashaeussler/phpunit-attributes.git",
+                "reference": "e83d9210492f3b4996c9075d91013f8a630c736e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/eliashaeussler/phpunit-attributes/zipball/e83d9210492f3b4996c9075d91013f8a630c736e",
+                "reference": "e83d9210492f3b4996c9075d91013f8a630c736e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "phpunit/phpunit": "^10.5.35 || ^11.4 || ^12.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^1.8 || ^2.0",
+                "eliashaeussler/php-cs-fixer-config": "^2.0",
+                "eliashaeussler/phpstan-config": "^2.5.1",
+                "eliashaeussler/rector-config": "^3.0",
+                "ergebnis/composer-normalize": "^2.30",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpcov": "^9.0 || ^10.0 || ^11.0",
+                "symfony/console": "^6.4 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "EliasHaeussler\\PHPUnitAttributes\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Elias Häußler",
+                    "email": "elias@haeussler.dev",
+                    "homepage": "https://haeussler.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Provides additional attributes for tests with PHPUnit",
+            "support": {
+                "issues": "https://github.com/eliashaeussler/phpunit-attributes/issues",
+                "source": "https://github.com/eliashaeussler/phpunit-attributes/tree/1.3.0"
+            },
+            "time": "2025-02-28T17:51:10+00:00"
         },
         {
             "name": "eliashaeussler/typo3-codeception-helper",

--- a/phpunit.unit.xml
+++ b/phpunit.unit.xml
@@ -5,6 +5,9 @@
          colors="true"
          xsi:noNamespaceSchemaLocation=".Build/vendor/phpunit/phpunit/phpunit.xsd"
 >
+    <extensions>
+        <bootstrap class="EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension"/>
+    </extensions>
     <coverage>
         <report>
             <php outputFile=".Build/coverage/php/unit.cov"/>


### PR DESCRIPTION
This pull request includes several changes to the unit tests and configuration files to improve compatibility and functionality. The key changes involve adding a new PHPUnit extension, updating dependencies, and cleaning up test conditions.

Improvements to unit tests:

* [`Tests/Unit/Compatibility/Migration/HmacHashMigrationTest.php`](diffhunk://#diff-6997c201162997911d4952a3a8249baced3146f5e90e3558aa6730a8e6e4368eR26-L28): Added `PHPUnitAttributes\Attribute\RequiresPackage` attribute to ensure tests are only run with TYPO3 v13 or higher, and removed the conditional check in the `setUp` method. [[1]](diffhunk://#diff-6997c201162997911d4952a3a8249baced3146f5e90e3558aa6730a8e6e4368eR26-L28) [[2]](diffhunk://#diff-6997c201162997911d4952a3a8249baced3146f5e90e3558aa6730a8e6e4368eR38-R39) [[3]](diffhunk://#diff-6997c201162997911d4952a3a8249baced3146f5e90e3558aa6730a8e6e4368eL48-L52)

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R39): Added `eliashaeussler/phpunit-attributes` as a new dependency.

Configuration updates:

* [`phpunit.unit.xml`](diffhunk://#diff-716082fd8316188f0ba146d3053fc566568313b74ee4ee216e105307dc6cb9b9R8-R10): Added `EliasHaeussler\PHPUnitAttributes\PHPUnitAttributesExtension` as a PHPUnit extension to enable the use of custom attributes.