### PR TITLE
Mark form finishers as approval/dismissal dependant via form editor

### DIFF
--- a/Classes/Domain/Variants/ConsentVariantManager.php
+++ b/Classes/Domain/Variants/ConsentVariantManager.php
@@ -23,31 +23,84 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3FormConsent\Domain\Variants;
 
-final class ConsentVariantManager
+class ConsentVariantManager
 {
+    private const CONSENT_VARIANT_IDENTIFIERS = [
+        'approval' => '1265789653-post-consent-approval-variant',
+        'dismissal' => '1265789653-post-consent-dismissal-variant'
+    ];
+    public const FINISHER_CONSENT_FLAGS = [
+        'approval' => 'needsApproval',
+        'dismissal' => 'needsDismissal'
+    ];
+    public const CONSENT_VARIANT_CONDITIONS = [
+        'approval' => 'isConsentApproved()',
+        'dismissal' => 'isConsentDismissed()'
+    ];
 
-    public const CONSENT_APPROVED_VARIANT_IDENTIFIER = '1265789653-post-consent-approval-variant';
-    public const CONSENT_APPROVED_VARIANT_CONDITION = 'isConsentApproved()';
-
+    /**
+     * Used before showing the form definition in editor
+     * @param array $formDefinition
+     * @return array
+     */
     public function streamlineFormFinishers(array $formDefinition): array
     {
         $consentFinishers = $this->getConsentVariantFinishers($formDefinition);
-        $formDefinition =  $this->mergeFinishers(
+        $formDefinition = $this->mergeFinishers(
             $formDefinition,
             $consentFinishers
         );
-        return $this->removeConsentVariant($formDefinition);
+        return $this->removeConsentVariants($formDefinition);
     }
 
     /**
-     * We always reset the consent variant
+     * Used before saving the form definition
      * @param array $form
      * @return array
      */
-    public function removeConsentVariant(array $form): array
+    public function addConsentVariants(array $form = []): array
+    {
+        if (!$this->formHasConsentFinisher($form)) {
+            return $form;
+        }
+        // reset
+        $form = $this->removeConsentVariants($form);
+
+        foreach (['approval', 'dismissal'] as $condition) {
+            $finishersWithCondition = $this->findFinishersWithConsentCondition(
+                $form,
+                self::FINISHER_CONSENT_FLAGS[$condition]
+            );
+            $form = $this->createConsentVariant($form, $finishersWithCondition, $condition);
+            $form = $this->removeFinishersWithConsentConditionFromDefault($form, $finishersWithCondition);
+        }
+
+        return $form;
+    }
+
+    protected function createConsentVariant(array $form, array $finishersWithApprovalCondition, string $condition): array
+    {
+        // exit if no finishers in variant
+        if (empty($finishersWithApprovalCondition)) {
+            return $form;
+        }
+        $form['variants'][] = [
+            'identifier' => self::CONSENT_VARIANT_IDENTIFIERS[$condition],
+            'condition' => self::CONSENT_VARIANT_CONDITIONS[$condition],
+            'finishers' => $finishersWithApprovalCondition
+        ];
+        return $form;
+    }
+
+    /**
+     * removes all consent relates form variants, used as reset before rebuilding the variants
+     * @param array $form
+     * @return array
+     */
+    protected function removeConsentVariants(array $form = []): array
     {
         foreach ($form['variants'] ?? [] as $key => $variant) {
-            if (($variant['identifier'] ?? '') === self::CONSENT_APPROVED_VARIANT_IDENTIFIER) {
+            if (in_array(($variant['identifier'] ?? ''), self::CONSENT_VARIANT_IDENTIFIERS)) {
                 unset($form['variants'][$key]);
             }
         }
@@ -59,26 +112,28 @@ final class ConsentVariantManager
     }
 
     /**
-     * We always reset the consent variant
      * @param array $form
      * @return array
      */
-    public function getConsentVariantFinishers(array $form): array
+    protected function getConsentVariantFinishers(array $form): array
     {
+        $variantFinishers = [];
         foreach ($form['variants'] ?? [] as $variant) {
-            if (($variant['identifier'] ?? '') === self::CONSENT_APPROVED_VARIANT_IDENTIFIER) {
-                return $variant['finishers'] ?? [];
+            if (in_array(($variant['identifier'] ?? ''), self::CONSENT_VARIANT_IDENTIFIERS)) {
+                $variantFinishers = array_merge($variantFinishers, $variant['finishers'] ?? []);
             }
         }
-        return [];
+        return $variantFinishers;
     }
 
     /**
+     * Since variants are not shown in the form editor,
+     * we combine the default finishers with the variants finishers
      * @param array $formDefinition
      * @param array $variantFinishers
      * @return array
      */
-    public function mergeFinishers(array $formDefinition, array $variantFinishers): array
+    protected function mergeFinishers(array $formDefinition, array $variantFinishers): array
     {
         $formDefinition['finishers'] = array_merge($formDefinition['finishers'] ?? [], $variantFinishers);
         return $formDefinition;
@@ -86,30 +141,31 @@ final class ConsentVariantManager
 
     /**
      * @param array $form
+     * @param $consentOptionValue
      * @return array
      */
-    public function findFinishersWithConsentNeeded(array $form): array
+    protected function findFinishersWithConsentCondition(array $form, $consentOptionValue): array
     {
-        $finishersThatNeedConsent = [];
+        $finishersWithConsentCondition = [];
         foreach ((array)($form['finishers'] ?? []) as $finisher) {
             $options = (array)($finisher['options'] ?? []);
-            if ($options['needsConsent'] ?? false) {
-                $finishersThatNeedConsent[] = $finisher;
+            if (($options['consentCondition'] ?? '') === $consentOptionValue) {
+                $finishersWithConsentCondition[] = $finisher;
             }
         }
-        return $finishersThatNeedConsent;
+        return $finishersWithConsentCondition;
     }
 
     /**
      * @param array $form
-     * @param $finishersWithConsentNeeded
+     * @param $finishersWithConsentCondition
      * @return array
      */
-    public function removeFinishersWithConsentNeededFromDefault(array $form, $finishersWithConsentNeeded): array
+    protected function removeFinishersWithConsentConditionFromDefault(array $form, $finishersWithConsentCondition): array
     {
         $form['finishers'] = array_values(array_udiff(
             $form['finishers'] ?? [],
-            $finishersWithConsentNeeded,
+            $finishersWithConsentCondition,
             function ($a, $b) {
                 return $a <=> $b;
             }));
@@ -120,7 +176,7 @@ final class ConsentVariantManager
      * @param array $form
      * @return bool
      */
-    public function formHasConsentFinisher(array $form): bool
+    protected function formHasConsentFinisher(array $form): bool
     {
         foreach ($form['finishers'] ?? [] as $finisher) {
             if ($finisher['identifier'] ?? '' === 'Consent') {

--- a/Classes/Domain/Variants/ConsentVariantManager.php
+++ b/Classes/Domain/Variants/ConsentVariantManager.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Domain\Variants;
+
+final class ConsentVariantManager
+{
+
+    public const CONSENT_APPROVED_VARIANT_IDENTIFIER = '1265789653-post-consent-approval-variant';
+    public const CONSENT_APPROVED_VARIANT_CONDITION = 'isConsentApproved()';
+
+    public function streamlineFormFinishers(array $formDefinition): array
+    {
+        $consentFinishers = $this->getConsentVariantFinishers($formDefinition);
+        $formDefinition =  $this->mergeFinishers(
+            $formDefinition,
+            $consentFinishers
+        );
+        return $this->removeConsentVariant($formDefinition);
+    }
+
+    /**
+     * We always reset the consent variant
+     * @param array $form
+     * @return array
+     */
+    public function removeConsentVariant(array $form): array
+    {
+        foreach ($form['variants'] ?? [] as $key => $variant) {
+            if (($variant['identifier'] ?? '') === self::CONSENT_APPROVED_VARIANT_IDENTIFIER) {
+                unset($form['variants'][$key]);
+            }
+        }
+        $form['variants'] = array_values($form['variants'] ?? []);
+        if (empty($form['variants'])) {
+            unset($form['variants']);
+        }
+        return $form;
+    }
+
+    /**
+     * We always reset the consent variant
+     * @param array $form
+     * @return array
+     */
+    public function getConsentVariantFinishers(array $form): array
+    {
+        foreach ($form['variants'] ?? [] as $variant) {
+            if (($variant['identifier'] ?? '') === self::CONSENT_APPROVED_VARIANT_IDENTIFIER) {
+                return $variant['finishers'] ?? [];
+            }
+        }
+        return [];
+    }
+
+    /**
+     * @param array $formDefinition
+     * @param array $variantFinishers
+     * @return array
+     */
+    public function mergeFinishers(array $formDefinition, array $variantFinishers): array
+    {
+        $formDefinition['finishers'] = array_merge($formDefinition['finishers'] ?? [], $variantFinishers);
+        return $formDefinition;
+    }
+
+    /**
+     * @param array $form
+     * @return array
+     */
+    public function findFinishersWithConsentNeeded(array $form): array
+    {
+        $finishersThatNeedConsent = [];
+        foreach ((array)($form['finishers'] ?? []) as $finisher) {
+            $options = (array)($finisher['options'] ?? []);
+            if ($options['needsConsent'] ?? false) {
+                $finishersThatNeedConsent[] = $finisher;
+            }
+        }
+        return $finishersThatNeedConsent;
+    }
+
+    /**
+     * @param array $form
+     * @param $finishersWithConsentNeeded
+     * @return array
+     */
+    public function removeFinishersWithConsentNeededFromDefault(array $form, $finishersWithConsentNeeded): array
+    {
+        $form['finishers'] = array_values(array_udiff(
+            $form['finishers'] ?? [],
+            $finishersWithConsentNeeded,
+            function ($a, $b) {
+                return $a <=> $b;
+            }));
+        return $form;
+    }
+
+    /**
+     * @param array $form
+     * @return bool
+     */
+    public function formHasConsentFinisher(array $form): bool
+    {
+        foreach ($form['finishers'] ?? [] as $finisher) {
+            if ($finisher['identifier'] ?? '' === 'Consent') {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Classes/Event/Listener/AfterFormDefinitionLoadedEventListener.php
+++ b/Classes/Event/Listener/AfterFormDefinitionLoadedEventListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Event\Listener;
+
+use EliasHaeussler\Typo3FormConsent\Domain\Variants\ConsentVariantManager;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Form\Mvc\Persistence\Event\AfterFormDefinitionLoadedEvent;
+
+/**
+ * This class takes form finishers from the consent variant and lines them up with the
+ * global finishers.
+ */
+
+class AfterFormDefinitionLoadedEventListener
+{
+
+    public function __construct(
+        private readonly ConsentVariantManager $consentVariantManager
+    ){}
+
+    #[AsEventListener(
+        identifier: 'AfterFormDefinitionLoadedEventListener',
+        event: AfterFormDefinitionLoadedEvent::class)
+    ]
+    public function __invoke(AfterFormDefinitionLoadedEvent $event)
+    {
+        // Make sure handler does only get called when processing the form definition in backend
+        if (ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()) {
+            $event->setFormDefinition(
+                $this->consentVariantManager->streamlineFormFinishers(
+                    $event->getFormDefinition()
+                )
+            );
+        }
+    }
+}

--- a/Classes/Event/Listener/AfterFormDefinitionLoadedEventListener.php
+++ b/Classes/Event/Listener/AfterFormDefinitionLoadedEventListener.php
@@ -40,10 +40,11 @@ class AfterFormDefinitionLoadedEventListener
         private readonly ConsentVariantManager $consentVariantManager
     ){}
 
-    #[AsEventListener(
+    // @todo Enable attribute once support for TYPO3 v12 is dropped
+    /*#[AsEventListener(
         identifier: 'AfterFormDefinitionLoadedEventListener',
         event: AfterFormDefinitionLoadedEvent::class)
-    ]
+    ]*/
     public function __invoke(AfterFormDefinitionLoadedEvent $event)
     {
         // Make sure handler does only get called when processing the form definition in backend

--- a/Classes/Extension.php
+++ b/Classes/Extension.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3FormConsent;
 
+use EliasHaeussler\Typo3FormConsent\Hooks\ModifyFormVariantsHook;
 use TYPO3\CMS\Core;
 use TYPO3\CMS\Extbase;
 use TYPO3\CMS\Scheduler;
@@ -124,5 +125,18 @@ final class Extension
                 }
             }
         ');
+    }
+
+    /**
+     * Register hooks to set form variants depending on finisher settings.
+     *
+     * FOR USE IN ext_localconf.php ONLY.
+     */
+    public static function registerFormVariantHooks(): void
+    {
+        foreach (['beforeFormCreate', 'beforeFormSave'] as $hook) {
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form'][$hook]['1740825683'] =
+                ModifyFormVariantsHook::class;
+        }
     }
 }

--- a/Classes/Hooks/ModifyFormVariantsHook.php
+++ b/Classes/Hooks/ModifyFormVariantsHook.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Hooks;
+
+use EliasHaeussler\Typo3FormConsent\Domain\Variants\ConsentVariantManager;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+/**
+ * Event listener to create form variants
+ */
+#[Autoconfigure(public: true)]
+class ModifyFormVariantsHook
+{
+    public function __construct(protected ConsentVariantManager $consentVariantManager){}
+
+    /**
+     * @param string $formPersistenceIdentifier
+     * @param array $form
+     * @return array
+     */
+    public function beforeFormCreate(string $formPersistenceIdentifier, array $form): array
+    {
+        return $this->createVariantsWithFinishers($form);
+    }
+
+    /**
+     * @param string $formPersistenceIdentifier
+     * @param array $form
+     * @return array
+     */
+    public function beforeFormSave(string $formPersistenceIdentifier, array $form): array
+    {
+        return $this->createVariantsWithFinishers($form);
+    }
+
+    protected function createVariantsWithFinishers(array $form): array
+    {
+        // modify variants only if Consent finisher is selected
+        if (!$this->consentVariantManager->formHasConsentFinisher($form)) {
+            return $form;
+        }
+
+        $finishersThatNeedConsent = $this->consentVariantManager->findFinishersWithConsentNeeded($form);
+
+        // always rebuild consent variants
+        $form = $this->consentVariantManager->removeConsentVariant($form);
+
+        if (!empty($finishersThatNeedConsent)) {
+            $form = $this->consentVariantManager->removeFinishersWithConsentNeededFromDefault($form, $finishersThatNeedConsent);
+            $consentVariant = [];
+            $consentVariant['identifier'] = ConsentVariantManager::CONSENT_APPROVED_VARIANT_IDENTIFIER;
+            $consentVariant['condition'] = ConsentVariantManager::CONSENT_APPROVED_VARIANT_CONDITION;
+            $consentVariant['finishers'] = $finishersThatNeedConsent;
+            $form['variants'][] = $consentVariant;
+        }
+        return $form;
+    }
+}

--- a/Classes/Middleware/FormVariantMiddleware.php
+++ b/Classes/Middleware/FormVariantMiddleware.php
@@ -28,22 +28,20 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Http\ApplicationType;
-use TYPO3\CMS\Core\Http\NullResponse;
 use TYPO3\CMS\Core\Http\Stream;
-use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
 
 /**
  * Modify Form Editor output.
  */
-#[Autoconfigure(public: true)]
 class FormVariantMiddleware implements MiddlewareInterface
 {
     public function __construct(protected ConsentVariantManager $consentVariantManager){}
 
     /**
-     *
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/Classes/Middleware/FormVariantMiddleware.php
+++ b/Classes/Middleware/FormVariantMiddleware.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Middleware;
+
+use EliasHaeussler\Typo3FormConsent\Domain\Variants\ConsentVariantManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Http\NullResponse;
+use TYPO3\CMS\Core\Http\Stream;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+
+/**
+ * Modify Form Editor output.
+ */
+#[Autoconfigure(public: true)]
+class FormVariantMiddleware implements MiddlewareInterface
+{
+    public function __construct(protected ConsentVariantManager $consentVariantManager){}
+
+    /**
+     *
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+        if (!$this->requestIsInFormEditor($request)) {
+            return $response;
+        }
+        $body = $response->getBody();
+        $body->rewind();
+        $content = $response->getBody()->getContents();
+        $contentArray = json_decode($content, true);
+        $formDefinition = $contentArray['formDefinition'] ?? [];
+        if (!empty($formDefinition)) {
+            $formDefinition = $this->consentVariantManager->streamlineFormFinishers($formDefinition);
+            $contentArray['formDefinition'] = $formDefinition;
+            $newContent = json_encode($contentArray);
+            $body = new Stream('php://temp', 'rw');
+            $body->write($newContent);
+            return $response->withBody($body);
+        }
+        return $response;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @return bool
+     */
+    protected function requestIsInFormEditor(ServerRequestInterface $request): bool
+    {
+        if (!ApplicationType::fromRequest($request)->isBackend()) {
+            return false;
+        }
+        return $request->getUri()->getPath() === '/typo3/module/manage/forms/FormEditor/saveForm';
+    }
+}

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,0 +1,12 @@
+<?php
+
+use EliasHaeussler\Typo3FormConsent\Middleware\FormVariantMiddleware;
+
+return [
+    'backend' => [
+        'form-consent/form-variants--middleware' => [
+            'target' => FormVariantMiddleware::class
+        ],
+    ],
+];
+

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -22,8 +22,18 @@ services:
         identifier: 'formConsentInvokeFinishersOnConsentDismissListener'
         method: 'onConsentDismiss'
 
+  EliasHaeussler\Typo3FormConsent\Event\Listener\AfterFormDefinitionLoadedEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'formConsentAfterFormDefinitionLoadedEventListener'
+
+  EliasHaeussler\Typo3FormConsent\Hooks\ModifyFormVariantHook:
+    public: true
+
   connection.tx_formconsent_domain_model_consent:
     class: 'TYPO3\CMS\Core\Database\Connection'
     factory: ['@TYPO3\CMS\Core\Database\ConnectionPool', 'getConnectionForTable']
     arguments:
       - !php/const EliasHaeussler\Typo3FormConsent\Domain\Model\Consent::TABLE_NAME
+
+

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -119,6 +119,22 @@ prototypes:
                   9999:
                     identifier: removeButton
                     templateName: Inspector-RemoveElementEditor
+              10:
+                editors:
+                  1500:
+                    identifier: needsConsent
+                    templateName: Inspector-CheckboxEditor
+                    label: formEditor.elements.Form.finisher.editor.needsConsent.label
+                    propertyPath: options.needsConsent
+                    fieldExplanationText: formEditor.elements.Form.finisher.editor.needsConsent.fieldExplanationText
+              20:
+                editors:
+                  1500:
+                    identifier: needsConsent
+                    templateName: Inspector-CheckboxEditor
+                    label: formEditor.elements.Form.finisher.editor.needsConsent.label
+                    propertyPath: options.needsConsent
+                    fieldExplanationText: formEditor.elements.Form.finisher.editor.needsConsent.fieldExplanationText
     formEngine:
       translationFiles:
         1632317570: 'EXT:form_consent/Resources/Private/Language/locallang_form.xlf'

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -122,19 +122,88 @@ prototypes:
               10:
                 editors:
                   1500:
-                    identifier: needsConsent
-                    templateName: Inspector-CheckboxEditor
-                    label: formEditor.elements.Form.finisher.editor.needsConsent.label
-                    propertyPath: options.needsConsent
-                    fieldExplanationText: formEditor.elements.Form.finisher.editor.needsConsent.fieldExplanationText
+                    identifier: consentCondition
+                    templateName: Inspector-SingleSelectEditor
+                    label: formEditor.elements.Form.finisher.editor.consentCondition.label
+                    propertyPath: options.consentCondition
+                    selectOptions:
+                      10:
+                        value: ''
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.noConditionNeeded
+                      15:
+                        value: 'needsApproval'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsApproval
+                      20:
+                        value: 'needsDismissal'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsDismissal
               20:
                 editors:
                   1500:
-                    identifier: needsConsent
-                    templateName: Inspector-CheckboxEditor
-                    label: formEditor.elements.Form.finisher.editor.needsConsent.label
-                    propertyPath: options.needsConsent
-                    fieldExplanationText: formEditor.elements.Form.finisher.editor.needsConsent.fieldExplanationText
+                    identifier: consentCondition
+                    templateName: Inspector-SingleSelectEditor
+                    label: formEditor.elements.Form.finisher.editor.consentCondition.label
+                    propertyPath: options.consentCondition
+                    selectOptions:
+                      10:
+                        value: ''
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.noConditionNeeded
+                      15:
+                        value: 'needsApproval'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsApproval
+                      20:
+                        value: 'needsDismissal'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsDismissal
+              30:
+                editors:
+                  1500:
+                    identifier: consentCondition
+                    templateName: Inspector-SingleSelectEditor
+                    label: formEditor.elements.Form.finisher.editor.consentCondition.label
+                    propertyPath: options.consentCondition
+                    selectOptions:
+                      10:
+                        value: ''
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.noConditionNeeded
+                      15:
+                        value: 'needsApproval'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsApproval
+                      20:
+                        value: 'needsDismissal'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsDismissal
+              40:
+                editors:
+                  1500:
+                    identifier: consentCondition
+                    templateName: Inspector-SingleSelectEditor
+                    label: formEditor.elements.Form.finisher.editor.consentCondition.label
+                    propertyPath: options.consentCondition
+                    selectOptions:
+                      10:
+                        value: ''
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.noConditionNeeded
+                      15:
+                        value: 'needsApproval'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsApproval
+                      20:
+                        value: 'needsDismissal'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsDismissal
+              50:
+                editors:
+                  1500:
+                    identifier: consentCondition
+                    templateName: Inspector-SingleSelectEditor
+                    label: formEditor.elements.Form.finisher.editor.consentCondition.label
+                    propertyPath: options.consentCondition
+                    selectOptions:
+                      10:
+                        value: ''
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.noConditionNeeded
+                      15:
+                        value: 'needsApproval'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsApproval
+                      20:
+                        value: 'needsDismissal'
+                        label: formEditor.elements.Form.finisher.editor.consentCondition.option.needsDismissal
     formEngine:
       translationFiles:
         1632317570: 'EXT:form_consent/Resources/Private/Language/locallang_form.xlf'

--- a/Resources/Private/Language/locallang_form.xlf
+++ b/Resources/Private/Language/locallang_form.xlf
@@ -68,11 +68,17 @@
 				<source>Enable this checkbox if users must verify their consent dismissal by additionally clicking on a link on the consent validation page. This is especially useful to avoid that automatic mail link scanners accidentally dismissing a consent.</source>
 			</trans-unit>
 
-			<trans-unit id="formEditor.elements.Form.finisher.editor.needsConsent.label" resname="formEditor.elements.Form.finisher.editor.needsConsent.label">
-				<source>Finisher needs consent</source>
+			<trans-unit id="formEditor.elements.Form.finisher.editor.consentCondition.label" resname="formEditor.elements.Form.finisher.editor.consentCondition.label">
+				<source>Consent conditions</source>
 			</trans-unit>
-			<trans-unit id="formEditor.elements.Form.finisher.editor.needsConsent.fieldExplanationText" resname="formEditor.elements.Form.finisher.editor.needsConsent.fieldExplanationText">
-				<source>Enable this checkbox if this finisher should be invoked after consent. Please note. If you enable this checkbox, please make sure that a Consent finisher is present in this form</source>
+			<trans-unit id="formEditor.elements.Form.finisher.editor.consentCondition.option.noConditionNeeded" resname="formEditor.elements.Form.finisher.editor.consentCondition.option.noConditionNeeded">
+				<source>No condition (default behaviour)</source>
+			</trans-unit>
+			<trans-unit id="formEditor.elements.Form.finisher.editor.consentCondition.option.needsApproval" resname="formEditor.elements.Form.finisher.editor.consentCondition.option.needsApproval">
+				<source>Approval (Consent finisher needed)</source>
+			</trans-unit>
+			<trans-unit id="formEditor.elements.Form.finisher.editor.consentCondition.option.needsDismissal" resname="formEditor.elements.Form.finisher.editor.consentCondition.option.needsDismissal">
+				<source>Dismissal (Consent finisher needed)</source>
 			</trans-unit>
 
 			<trans-unit id="formEditor.elements.Form.finisher.Consent.editor.header.label" resname="formEditor.elements.Form.finisher.Consent.editor.header.label">

--- a/Resources/Private/Language/locallang_form.xlf
+++ b/Resources/Private/Language/locallang_form.xlf
@@ -68,6 +68,13 @@
 				<source>Enable this checkbox if users must verify their consent dismissal by additionally clicking on a link on the consent validation page. This is especially useful to avoid that automatic mail link scanners accidentally dismissing a consent.</source>
 			</trans-unit>
 
+			<trans-unit id="formEditor.elements.Form.finisher.editor.needsConsent.label" resname="formEditor.elements.Form.finisher.editor.needsConsent.label">
+				<source>Finisher needs consent</source>
+			</trans-unit>
+			<trans-unit id="formEditor.elements.Form.finisher.editor.needsConsent.fieldExplanationText" resname="formEditor.elements.Form.finisher.editor.needsConsent.fieldExplanationText">
+				<source>Enable this checkbox if this finisher should be invoked after consent. Please note. If you enable this checkbox, please make sure that a Consent finisher is present in this form</source>
+			</trans-unit>
+
 			<trans-unit id="formEditor.elements.Form.finisher.Consent.editor.header.label" resname="formEditor.elements.Form.finisher.Consent.editor.header.label">
 				<source>Consent</source>
 			</trans-unit>

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -27,11 +27,11 @@ $EM_CONF[$_EXTKEY] = [
     'author' => 'Elias Häußler',
     'author_email' => 'elias@haeussler.dev',
     'state' => 'stable',
-    'version' => '3.1.2',
+    'version' => '4.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.21-13.4.99',
-            'php' => '8.1.0-8.4.99',
+            'typo3' => '13.4.0-13.4.99',
+            'php' => '8.2.0-8.4.99',
         ],
     ],
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -24,3 +24,4 @@
 \EliasHaeussler\Typo3FormConsent\Extension::registerPlugin();
 \EliasHaeussler\Typo3FormConsent\Extension::registerGarbageCollectionTask();
 \EliasHaeussler\Typo3FormConsent\Extension::registerTypoScript();
+\EliasHaeussler\Typo3FormConsent\Extension::registerFormVariantHooks();


### PR DESCRIPTION
Adresses #353

This branch contains consent options for common finishers: Users can mark a finisher as consent dependant, the form definition gets saved with variants, and the finishers get recombined into one list when reopeneing the form in editor. 

[WIP] I have tested this feature with TYPO3 13.4, I can do more tests/documentation.

Thank you for your work!