### PR TITLE
[TASK] Use PCOV to collect code coverage

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -15,12 +15,12 @@ hooks:
         - composer: install
         - exec-host: ddev init-typo3
 omit_containers: [ddev-ssh-agent]
+webimage_extra_packages: [php8.3-pcov]
 use_dns_when_possible: true
 composer_version: "2"
 disable_settings_management: true
 web_environment:
     - TESTING_DOMAIN=$DDEV_HOSTNAME
-    - XDEBUG_MODE=coverage
     - TYPO3_CONTEXT=Development/DDEV
     - typo3DatabaseHost=db
     - typo3DatabaseUsername=root

--- a/.ddev/php/pcov.ini
+++ b/.ddev/php/pcov.ini
@@ -1,0 +1,1 @@
+pcov.directory=/var/www/html/Classes

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -102,7 +102,7 @@ jobs:
           autostart: false
       - name: Configure and start DDEV
         run: |
-          ddev config --project-type=typo3 --xdebug-enabled=true
+          ddev config --project-type=typo3
           ddev start
 
       # Run tests


### PR DESCRIPTION
This pull request includes changes to the DDEV configuration and GitHub Actions workflow to improve the setup for TYPO3 development and testing. The most important changes include adding a new PHP package, configuring PCOV, and adjusting the DDEV configuration.

### DDEV Configuration Updates:

* [`.ddev/config.yaml`](diffhunk://#diff-ca25b57a32546d43021f7de9e5374004e498a3cc2ec9b4be3c820daa1e896e57R18-L23): Added `php8.3-pcov` to `webimage_extra_packages` and removed `XDEBUG_MODE=coverage` from `web_environment`.

### PCOV Configuration:

* [`.ddev/php/pcov.ini`](diffhunk://#diff-39e9e7d345ae595ff74fbeaa727b18bdbd03b3295976b8adda4e1957c25f00a8R1): Added PCOV configuration to set the directory to `/var/www/html/Classes`.

### GitHub Actions Workflow:

* [`.github/workflows/tests.yaml`](diffhunk://#diff-95557d53bf91069e59d82b9d8fcfaf52ec84a762858983edd5ef3c9b3e4c8191L105-R105): Updated the DDEV configuration command to remove the `--xdebug-enabled=true` flag.