### PR TITLE
[BUGFIX] Disable third-party hooks when invoking finishers

### DIFF
--- a/Classes/Event/Listener/InvokeFinishersListener.php
+++ b/Classes/Event/Listener/InvokeFinishersListener.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3FormConsent\Event\Listener;
 
+use Derhansen\FormCrshield;
 use EliasHaeussler\Typo3FormConsent\Compatibility;
 use EliasHaeussler\Typo3FormConsent\Domain;
 use EliasHaeussler\Typo3FormConsent\Event;
@@ -38,6 +39,7 @@ use TYPO3\CMS\Frontend;
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
+ * @internal
  */
 final class InvokeFinishersListener
 {
@@ -119,6 +121,10 @@ final class InvokeFinishersListener
             'pluginName' => 'Formframework',
         ];
 
+        // Prepare clean environment
+        $globalsBackup = $GLOBALS;
+        $this->disableThirdPartyHooks();
+
         try {
             // Dispatch extbase request
             $content = $bootstrap->run('', $configuration, $serverRequest);
@@ -129,6 +135,11 @@ final class InvokeFinishersListener
         } catch (Core\Http\ImmediateResponseException|Core\Http\PropagateResponseException $exception) {
             // If any immediate response is thrown, use this for further processing
             return $exception->getResponse();
+        } finally {
+            // Restore previous environment
+            foreach ($globalsBackup as $key => $value) {
+                $GLOBALS[$key] = $value;
+            }
         }
     }
 
@@ -192,6 +203,21 @@ final class InvokeFinishersListener
         return $this->getServerRequest()
             ->withMethod('POST')
             ->withParsedBody($originalRequestParameters->toArray());
+    }
+
+    private function disableThirdPartyHooks(): void
+    {
+        // Hooks from EXT:form_crshield must be disabled since they would avoid successful re-rendering
+        if (class_exists(FormCrshield\Hooks\Form::class)) {
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterInitializeCurrentPage'] = array_diff(
+                $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterInitializeCurrentPage'],
+                [FormCrshield\Hooks\Form::class],
+            );
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterSubmit'] = array_diff(
+                $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/form']['afterSubmit'],
+                [FormCrshield\Hooks\Form::class],
+            );
+        }
     }
 
     private function areFinisherVariantsConfigured(string $formPersistenceIdentifier, string $condition): bool

--- a/Tests/Acceptance/Frontend/Controller/ConsentControllerCest.php
+++ b/Tests/Acceptance/Frontend/Controller/ConsentControllerCest.php
@@ -56,7 +56,7 @@ final class ConsentControllerCest
         $I->seeInDatabase(
             Src\Domain\Model\Consent::TABLE_NAME,
             [
-                'data' => '{"email-1":"user@example.com","fileupload-1":null}',
+                'data like' => '{"cr-field":"%","email-1":"user@example.com","fileupload-1":null}',
                 'email' => 'user@example.com',
                 'state' => Src\Enums\ConsentState::Approved->value,
                 'form_persistence_identifier' => '1:/form_definitions/contact.form.yaml',
@@ -234,6 +234,17 @@ final class ConsentControllerCest
 
         $I->click('Dismiss');
         $I->see('Consent successfully revoked');
+    }
+
+    public function canApproveConsentWithThirdPartyHooksInstalled(Tests\Acceptance\Support\AcceptanceTester $I): void
+    {
+        $I->writeConfiguration('form_crshield', 'crJavaScriptDelay', '5');
+
+        $this->submitFormAndExtractUrls($I, Tests\Acceptance\Support\Helper\Form::CONFIRMATION_AFTER_APPROVE);
+
+        $I->amOnPage($this->approveUrl);
+
+        $I->see('Thanks for your consent.');
     }
 
     public function canPreviewValidationPluginWithActiveBackendSession(Tests\Acceptance\Support\AcceptanceTester $I): void

--- a/Tests/Acceptance/Frontend/Domain/Finishers/ConsentFinisherCest.php
+++ b/Tests/Acceptance/Frontend/Domain/Finishers/ConsentFinisherCest.php
@@ -50,7 +50,7 @@ final class ConsentFinisherCest
         $I->seeInDatabase(
             Src\Domain\Model\Consent::TABLE_NAME,
             [
-                'data' => '{"email-1":"user@example.com","fileupload-1":' . ($numberOfPersistedFiles + 1) . '}',
+                'data like' => '{"cr-field":"%","email-1":"user@example.com","fileupload-1":' . ($numberOfPersistedFiles + 1) . '}',
                 'email' => 'user@example.com',
                 'form_persistence_identifier' => '1:/form_definitions/contact.form.yaml',
                 'original_content_element_uid' => 1,
@@ -70,7 +70,7 @@ final class ConsentFinisherCest
             Src\Domain\Model\Consent::TABLE_NAME,
             'uid',
             [
-                'data' => '{"email-1":"user@example.com","fileupload-1":' . ($numberOfPersistedFiles + 1) . '}',
+                'data like' => '{"cr-field":"%","email-1":"user@example.com","fileupload-1":' . ($numberOfPersistedFiles + 1) . '}',
                 'email' => 'user@example.com',
                 'form_persistence_identifier' => '1:/form_definitions/contact.form.yaml',
                 'original_content_element_uid' => 1,

--- a/Tests/Acceptance/Support/Extension/EnvironmentExtension.php
+++ b/Tests/Acceptance/Support/Extension/EnvironmentExtension.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Extension;
 
 use Codeception\Events;
 use Codeception\Extension;
+use EliasHaeussler\Typo3FormConsent\Tests;
 use TYPO3\CMS\Core;
 use TYPO3\CMS\Install;
 
@@ -41,6 +42,8 @@ final class EnvironmentExtension extends Extension
      */
     public static array $events = [
         Events::SUITE_BEFORE => 'beforeSuite',
+        Events::TEST_BEFORE => 'beforeTest',
+        Events::TEST_AFTER => 'afterTest',
     ];
 
     public function beforeSuite(): void
@@ -51,5 +54,19 @@ final class EnvironmentExtension extends Extension
         // Fix folder structure
         $defaultFactory = Core\Utility\GeneralUtility::makeInstance(Install\FolderStructure\DefaultFactory::class);
         $defaultFactory->getStructure()->fix();
+    }
+
+    public function beforeTest(): void
+    {
+        /** @var Tests\Acceptance\Support\Helper\ExtensionConfiguration $extensionConfiguration */
+        $extensionConfiguration = $this->getModule(Tests\Acceptance\Support\Helper\ExtensionConfiguration::class);
+        $extensionConfiguration->writeConfiguration('form_crshield', 'crJavaScriptDelay', '1');
+    }
+
+    public function afterTest(): void
+    {
+        /** @var Tests\Acceptance\Support\Helper\ExtensionConfiguration $extensionConfiguration */
+        $extensionConfiguration = $this->getModule(Tests\Acceptance\Support\Helper\ExtensionConfiguration::class);
+        $extensionConfiguration->removeConfiguration('form_crshield', 'crJavaScriptDelay');
     }
 }

--- a/Tests/Acceptance/Support/Helper/ExtensionConfiguration.php
+++ b/Tests/Acceptance/Support/Helper/ExtensionConfiguration.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Helper;
+
+use Codeception\Module;
+use TYPO3\CMS\Core;
+
+/**
+ * ExtensionConfiguration
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ExtensionConfiguration extends Module
+{
+    private Core\Configuration\ConfigurationManager $configurationManager;
+
+    public function _initialize(): void
+    {
+        $this->configurationManager = Core\Utility\GeneralUtility::makeInstance(Core\Configuration\ConfigurationManager::class);
+    }
+
+    /**
+     * @param non-empty-string $extension
+     * @param non-empty-string $path
+     */
+    public function writeConfiguration(string $extension, string $path, mixed $value): void
+    {
+        $this->configurationManager->setLocalConfigurationValueByPath('EXTENSIONS/' . $extension . '/' . $path, $value);
+        $this->clearCache();
+    }
+
+    /**
+     * @param non-empty-string $extension
+     * @param non-empty-string $path
+     */
+    public function removeConfiguration(string $extension, string $path): void
+    {
+        $this->configurationManager->removeLocalConfigurationKeysByPath(['EXTENSIONS/' . $extension . '/' . $path]);
+        $this->clearCache();
+    }
+
+    private function clearCache(): void
+    {
+        /** @var Module\Cli $I */
+        $I = $this->getModule('Cli');
+        $I->runShellCommand('typo3 cache:flush');
+    }
+}

--- a/Tests/Acceptance/Support/Helper/Form.php
+++ b/Tests/Acceptance/Support/Helper/Form.php
@@ -56,10 +56,12 @@ final class Form extends Module
             $this->getFormElementName($form, 'email-1') => 'user@example.com',
         ];
 
+        $this->waitForCrChallenge($form);
+
         if ($attachFile) {
             $I->attachFile(
-                sprintf('[name="%s"]', $this->getFormElementName($form, 'fileupload-1')),
-                'dummy.png'
+                WebDriver\WebDriverBy::name($this->getFormElementName($form, 'fileupload-1')),
+                'dummy.png',
             );
         }
 
@@ -67,6 +69,20 @@ final class Form extends Module
             WebDriver\WebDriverBy::id($this->getFormElementIdentifier($form)),
             $elements,
             WebDriver\WebDriverBy::name($this->getFormElementName($form, '__currentPage'))
+        );
+    }
+
+    private function waitForCrChallenge(string $form): void
+    {
+        $I = $this->getWebDriver();
+
+        $crField = $this->getFormElementName($form, 'cr-field');
+        $initialValue = $I->grabValueFrom($crField);
+
+        $I->waitForElementChange(
+            WebDriver\WebDriverBy::name($crField),
+            static fn(WebDriver\WebDriverElement $element) => $element->getAttribute('value') !== $initialValue,
+            10,
         );
     }
 

--- a/Tests/CGL/composer-dependency-analyser.php
+++ b/Tests/CGL/composer-dependency-analyser.php
@@ -57,6 +57,7 @@ $configuration
     )
     ->ignoreErrorsOnPackages(
         [
+            'derhansen/form_crshield',
             'typo3/cms-dashboard',
             'typo3/cms-scheduler',
         ],

--- a/codeception.yml
+++ b/codeception.yml
@@ -27,12 +27,14 @@ suites:
             url: http://%TESTING_DOMAIN%/
             port: 8025
             deleteEmailsAfterScenario: true
+        - Cli
         - Asserts
         - EliasHaeussler\Typo3CodeceptionHelper\Codeception\Module\Backend:
             userCredentials:
               admin: password
         - EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Helper\Db
         - EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Helper\Email
+        - EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Helper\ExtensionConfiguration
         - EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Helper\Form
         - EliasHaeussler\Typo3FormConsent\Tests\Acceptance\Support\Helper\Url
 

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,10 @@
 	},
 	"require-dev": {
 		"codeception/module-asserts": "^3.0",
+		"codeception/module-cli": "^2.0",
 		"codeception/module-db": "^3.1",
 		"codeception/module-webdriver": "^4.0",
+		"derhansen/form_crshield": "^1.0 || ^2.0",
 		"eliashaeussler/phpunit-attributes": "^1.3",
 		"eliashaeussler/typo3-codeception-helper": "^1.2",
 		"eliashaeussler/typo3-form-consent-test-extension": "1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5a23837351cb3992f8225b5339d35b1",
+    "content-hash": "f6f66263f8621eae9b71291aaf7eaebf",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6067,6 +6067,54 @@
             "time": "2025-04-24T17:18:25+00:00"
         },
         {
+            "name": "codeception/module-cli",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeception/module-cli.git",
+                "reference": "a3a101fae4049fa2f810107f7bd5db3b3266ce63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeception/module-cli/zipball/a3a101fae4049fa2f810107f7bd5db3b3266ce63",
+                "reference": "a3a101fae4049fa2f810107f7bd5db3b3266ce63",
+                "shasum": ""
+            },
+            "require": {
+                "codeception/codeception": "*@dev",
+                "codeception/module-asserts": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "codeception/codeception": "<4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Bodnarchuk"
+                }
+            ],
+            "description": "Codeception module for testing basic shell commands and shell output",
+            "homepage": "https://codeception.com/",
+            "keywords": [
+                "codeception"
+            ],
+            "support": {
+                "issues": "https://github.com/Codeception/module-cli/issues",
+                "source": "https://github.com/Codeception/module-cli/tree/2.0.1"
+            },
+            "time": "2023-01-13T18:41:03+00:00"
+        },
+        {
             "name": "codeception/module-db",
             "version": "3.2.2",
             "source": {
@@ -6519,6 +6567,68 @@
                 }
             ],
             "time": "2024-11-26T16:23:11+00:00"
+        },
+        {
+            "name": "derhansen/form_crshield",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/derhansen/form_crshield.git",
+                "reference": "7d5e097a24feb4b1fce34748afef0a8dd85ca416"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/derhansen/form_crshield/zipball/7d5e097a24feb4b1fce34748afef0a8dd85ca416",
+                "reference": "7d5e097a24feb4b1fce34748afef0a8dd85ca416",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "typo3/cms-core": "^10.4.29 || ^11.5 || ^12.4",
+                "typo3/cms-extbase": "^10.4.29 || ^11.5 || ^12.4",
+                "typo3/cms-form": "^10.4.29 || ^11.5 || ^12.4",
+                "typo3/cms-frontend": "^10.4.29 || ^11.5 || ^12.4"
+            },
+            "replace": {
+                "typo3-ter/form-crshield": "self.version"
+            },
+            "type": "typo3-cms-extension",
+            "extra": {
+                "typo3/cms": {
+                    "extension-key": "form_crshield"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Derhansen\\FormCrshield\\": "Classes"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Torben Hansen",
+                    "email": "derhansen@gmail.com",
+                    "homepage": "https://www.derhansen.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Challenge/response spambot protection for TYPO3 ext:form",
+            "homepage": "https://github.com/derhansen/form_crshield",
+            "keywords": [
+                "TYPO3 CMS",
+                "challenge response",
+                "extbase",
+                "form",
+                "spam protection"
+            ],
+            "support": {
+                "issues": "https://github.com/derhansen/form_crshield/issues",
+                "source": "https://github.com/derhansen/form_crshield/tree/1.4.1"
+            },
+            "time": "2024-02-01T13:08:23+00:00"
         },
         {
             "name": "eliashaeussler/phpunit-attributes",


### PR DESCRIPTION
Third-party hooks for EXT:form may influence the behavior of re-rendering a form when invoking finishers after a consent is approved or dismissed. EXT:form_crshield, for example, is a candidate here, and hence needs to be disabled during form re-rendering.

Resolves: #180