### PR TITLE
[BUGFIX] Push translation sources into Crowdin branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
           config: '.crowdin.yaml'
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+          crowdin_branch_name: 'main'
 
   tests:
     name: Tests (PHP ${{ matrix.php-version }}, TYPO3 ${{ matrix.typo3-version }} & ${{ matrix.dependencies }} dependencies)


### PR DESCRIPTION
Source files at Crowdin need to be pushed into a dedicated branch in order to make the Crowdin Bridge work as expected.

Related: #377