### PR TITLE
[TASK] Sync ddev/ddev-selenium-standalone-chrome add-on

### DIFF
--- a/.ddev/addon-metadata/ddev-selenium-standalone-chrome/manifest.yaml
+++ b/.ddev/addon-metadata/ddev-selenium-standalone-chrome/manifest.yaml
@@ -1,7 +1,7 @@
 name: ddev-selenium-standalone-chrome
 repository: ddev/ddev-selenium-standalone-chrome
-version: 1.1.0
-install_date: "2024-10-14T13:08:16+02:00"
+version: 2.1.2
+install_date: "2026-02-19T21:34:08+01:00"
 project_files:
     - docker-compose.selenium-chrome.yaml
     - config.selenium-standalone-chrome.yaml

--- a/.ddev/docker-compose.selenium-chrome.yaml
+++ b/.ddev/docker-compose.selenium-chrome.yaml
@@ -17,8 +17,9 @@ services:
       - HTTPS_EXPOSE=7900:7900
       - HTTP_EXPOSE=7910:7900
       - VNC_NO_PASSWORD=1
-    external_links:
-      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
+        # Enables multiple parallel connections to the Selenium.
+      - SE_NODE_MAX_SESSIONS=12
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
     # To enable VNC access for traditional VNC clients like macOS "Screen Sharing",
     # uncomment the following two lines.
     #ports:
@@ -27,8 +28,6 @@ services:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     volumes:
+      # To enable file uploads in E2E tests.
+      - "../:/var/www/html"
       - ".:/mnt/ddev_config"
-
-  web:
-    links:
-      - selenium-chrome


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Selenium standalone Chrome testing addon to version 2.1.2
  * Enhanced Docker Compose configuration with optimized Selenium node settings including session management parameters
  * Added host volume mapping to support file uploads in test scenarios
  * Removed legacy service linking configuration
  * Improved testing infrastructure setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->