### PR TITLE
[BUGFIX] Mark datetime fields as nullable

### DIFF
--- a/Classes/Domain/Repository/ConsentRepository.php
+++ b/Classes/Domain/Repository/ConsentRepository.php
@@ -51,7 +51,11 @@ class ConsentRepository extends Extbase\Persistence\Repository
             $query->logicalAnd(
                 $query->equals('validation_hash', $validationHash),
                 $query->logicalOr(
-                    $query->equals('valid_until', 0),
+                    $query->logicalOr(
+                        // BC: Legacy consents may have been persisted with "0" instead of "NULL"
+                        $query->equals('valid_until', 0),
+                        $query->equals('valid_until', null),
+                    ),
                     $query->greaterThanOrEqual('valid_until', time()),
                 ),
             ),

--- a/Configuration/TCA/tx_formconsent_domain_model_consent.php
+++ b/Configuration/TCA/tx_formconsent_domain_model_consent.php
@@ -126,8 +126,8 @@ $tca = [
             'config' => [
                 'type' => 'datetime',
                 'format' => 'datetime',
-                'default' => 0,
                 'readOnly' => true,
+                'nullable' => true,
             ],
         ],
         'valid_until' => [
@@ -137,8 +137,8 @@ $tca = [
             'config' => [
                 'type' => 'datetime',
                 'format' => 'datetime',
-                'default' => 0,
                 'readOnly' => true,
+                'nullable' => true,
             ],
         ],
         'validation_hash' => [

--- a/Tests/Acceptance/Frontend/Controller/ConsentControllerCest.php
+++ b/Tests/Acceptance/Frontend/Controller/ConsentControllerCest.php
@@ -65,7 +65,7 @@ final class ConsentControllerCest
                 'original_content_element_uid' => 1,
                 'original_request_parameters !=' => null,
                 'validation_hash' => $hash,
-                'valid_until' => 0,
+                'valid_until' => null,
             ],
         );
     }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,5 +1,4 @@
 CREATE TABLE tx_formconsent_domain_model_consent(
 		data BLOB,
 		original_request_parameters BLOB,
-		update_date int(11),
 );


### PR DESCRIPTION
Resolves: #487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated timestamp field configurations to support nullable values, allowing certain date fields to remain empty when not yet applicable.
  * Refined database schema structure to align with updated field requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eliashaeussler/typo3-form-consent/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->