### PR TITLE
[BUGFIX] Avoid deprecations with TYPO3 v14 in classic mode

### DIFF
--- a/Tests/Functional/Domain/Finishers/ConsentFinisherTest.php
+++ b/Tests/Functional/Domain/Finishers/ConsentFinisherTest.php
@@ -44,6 +44,7 @@ final class ConsentFinisherTest extends Tests\Functional\ExtbaseRequestAwareFunc
     protected array $coreExtensionsToLoad = [
         'fluid_styled_content',
         'form',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
+++ b/Tests/Functional/Domain/Finishers/FinisherOptionsTest.php
@@ -42,6 +42,7 @@ final class FinisherOptionsTest extends TestingFramework\Core\Functional\Functio
 {
     protected array $coreExtensionsToLoad = [
         'form',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Domain/Repository/ConsentRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/ConsentRepositoryTest.php
@@ -39,6 +39,7 @@ final class ConsentRepositoryTest extends Tests\Functional\ExtbaseRequestAwareFu
     protected array $coreExtensionsToLoad = [
         'fluid_styled_content',
         'form',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/ExpressionLanguage/FunctionsProvider/ConsentConditionFunctionsProviderTest.php
+++ b/Tests/Functional/ExpressionLanguage/FunctionsProvider/ConsentConditionFunctionsProviderTest.php
@@ -40,6 +40,7 @@ final class ConsentConditionFunctionsProviderTest extends TestingFramework\Core\
 {
     protected array $coreExtensionsToLoad = [
         'form',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Service/HashServiceTest.php
+++ b/Tests/Functional/Service/HashServiceTest.php
@@ -40,6 +40,7 @@ final class HashServiceTest extends TestingFramework\Core\Functional\FunctionalT
 {
     protected array $testExtensionsToLoad = [
         'form_consent',
+        'install',
     ];
 
     protected array $coreExtensionsToLoad = [

--- a/Tests/Functional/Type/Transformer/FormValuesTypeTransformerTest.php
+++ b/Tests/Functional/Type/Transformer/FormValuesTypeTransformerTest.php
@@ -39,6 +39,7 @@ final class FormValuesTypeTransformerTest extends TestingFramework\Core\Function
 {
     protected array $coreExtensionsToLoad = [
         'form',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Widget/Provider/ConsentChartDataProviderTest.php
+++ b/Tests/Functional/Widget/Provider/ConsentChartDataProviderTest.php
@@ -39,6 +39,7 @@ final class ConsentChartDataProviderTest extends TestingFramework\Core\Functiona
 {
     protected array $coreExtensionsToLoad = [
         'form',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,7 @@
 				"providesPackages": {}
 			},
 			"extension-key": "form_consent",
+			"version": "4.2.2",
 			"web-dir": ".Build/web"
 		},
 		"version-bumper": {

--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,9 @@
 	},
 	"extra": {
 		"typo3/cms": {
+			"Package": {
+				"providesPackages": {}
+			},
 			"extension-key": "form_consent",
 			"web-dir": ".Build/web"
 		},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b561251def59c7cffb5e55642b636962",
+    "content-hash": "5646fe0749824a888e3091233ec2d9f4",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77fbc943ef11860d086c7552de081718",
+    "content-hash": "b561251def59c7cffb5e55642b636962",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extension metadata to identify version 4.2.2.
  * Added package capability metadata for improved TYPO3 extension integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->