### PR TITLE
[FEATURE] Allow to mark finishers as consent dependent in form editor

### DIFF
--- a/Classes/Enums/ConsentCondition.php
+++ b/Classes/Enums/ConsentCondition.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Enums;
+
+/**
+ * ConsentCondition
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+enum ConsentCondition: string
+{
+    case Approval = 'needsApproval';
+    case Dismissal = 'needsDismissal';
+
+    /**
+     * Name of the finisher option this condition is configured with.
+     */
+    public const FINISHER_OPTION = 'consentCondition';
+
+    /**
+     * Expression language condition, @see ConsentConditionFunctionsProvider.
+     */
+    public function condition(): string
+    {
+        return match ($this) {
+            self::Approval => 'isConsentApproved()',
+            self::Dismissal => 'isConsentDismissed()',
+        };
+    }
+
+    public function variantIdentifier(): string
+    {
+        return match ($this) {
+            self::Approval => 'form-consent-approval-variant',
+            self::Dismissal => 'form-consent-dismissal-variant',
+        };
+    }
+}

--- a/Classes/Event/Listener/ApplyFinisherVariantsListener.php
+++ b/Classes/Event/Listener/ApplyFinisherVariantsListener.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Event\Listener;
+
+use EliasHaeussler\Typo3FormConsent\Form;
+use Psr\Http\Message;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Form\Mvc;
+
+/**
+ * ApplyFinisherVariantsListener
+ *
+ * Applies consent dependent finishers as form variants during form runtime.
+ * The persisted form definition is intentionally left untouched, so the form
+ * editor keeps full control over the configured finishers.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final readonly class ApplyFinisherVariantsListener
+{
+    public function __construct(
+        private Form\ConsentVariantResolver $consentVariantResolver,
+    ) {}
+
+    #[Core\Attribute\AsEventListener('formConsentApplyFinisherVariantsListener')]
+    public function __invoke(Mvc\Persistence\Event\AfterFormDefinitionLoadedEvent $event): void
+    {
+        if (!$this->isFrontendRequest()) {
+            return;
+        }
+
+        $event->setFormDefinition(
+            $this->consentVariantResolver->resolve($event->getFormDefinition()),
+        );
+    }
+
+    private function isFrontendRequest(): bool
+    {
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+
+        if (
+            !$request instanceof Message\ServerRequestInterface
+            || !is_int($request->getAttribute('applicationType'))
+        ) {
+            return false;
+        }
+
+        return Core\Http\ApplicationType::fromRequest($request)->isFrontend();
+    }
+}

--- a/Classes/Form/ConsentVariantResolver.php
+++ b/Classes/Form/ConsentVariantResolver.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Form;
+
+use EliasHaeussler\Typo3FormConsent\Enums;
+
+/**
+ * ConsentVariantResolver
+ *
+ * Derives form variants from finishers that are marked as consent dependent in
+ * the form editor. Marked finishers are moved into a generated variant, since
+ * variants replace the whole finisher list once their condition matches.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ * @internal
+ */
+final class ConsentVariantResolver
+{
+    private const CONSENT_FINISHER_IDENTIFIER = 'Consent';
+
+    /**
+     * @param array<string, mixed> $formDefinition
+     * @return array<string, mixed>
+     */
+    public function resolve(array $formDefinition): array
+    {
+        $finishers = $formDefinition['finishers'] ?? null;
+
+        if (!is_array($finishers) || !$this->containsConsentFinisher($finishers)) {
+            return $formDefinition;
+        }
+
+        $defaultFinishers = [];
+        $consentDependentFinishers = [];
+
+        foreach ($finishers as $finisher) {
+            $condition = $this->resolveCondition($finisher);
+
+            if ($condition === null) {
+                $defaultFinishers[] = $finisher;
+            } else {
+                $consentDependentFinishers[$condition->value][] = $finisher;
+            }
+        }
+
+        if ($consentDependentFinishers === []) {
+            return $formDefinition;
+        }
+
+        $existingVariants = $formDefinition['variants'] ?? [];
+
+        $formDefinition['finishers'] = $defaultFinishers;
+        $formDefinition['variants'] = [
+            // Generated variants are prepended to allow manually configured
+            // variants to overrule them
+            ...$this->buildVariants($consentDependentFinishers),
+            ...(is_array($existingVariants) ? array_values($existingVariants) : []),
+        ];
+
+        return $formDefinition;
+    }
+
+    /**
+     * @param array<string, list<array<string, mixed>>> $consentDependentFinishers
+     * @return list<array{identifier: string, condition: string, finishers: list<array<string, mixed>>}>
+     */
+    private function buildVariants(array $consentDependentFinishers): array
+    {
+        $variants = [];
+
+        foreach (Enums\ConsentCondition::cases() as $condition) {
+            $finishers = $consentDependentFinishers[$condition->value] ?? [];
+
+            if ($finishers === []) {
+                continue;
+            }
+
+            $variants[] = [
+                'identifier' => $condition->variantIdentifier(),
+                'condition' => $condition->condition(),
+                'finishers' => $finishers,
+            ];
+        }
+
+        return $variants;
+    }
+
+    private function resolveCondition(mixed $finisher): ?Enums\ConsentCondition
+    {
+        // The Consent finisher triggers the conditions and must never be
+        // moved into a variant itself
+        if (!is_array($finisher) || $this->isConsentFinisher($finisher)) {
+            return null;
+        }
+
+        $options = $finisher['options'] ?? null;
+
+        if (!is_array($options) || !is_string($options[Enums\ConsentCondition::FINISHER_OPTION] ?? null)) {
+            return null;
+        }
+
+        return Enums\ConsentCondition::tryFrom($options[Enums\ConsentCondition::FINISHER_OPTION]);
+    }
+
+    /**
+     * @param array<mixed> $finishers
+     */
+    private function containsConsentFinisher(array $finishers): bool
+    {
+        foreach ($finishers as $finisher) {
+            if (is_array($finisher) && $this->isConsentFinisher($finisher)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $finisher
+     */
+    private function isConsentFinisher(array $finisher): bool
+    {
+        return ($finisher['identifier'] ?? null) === self::CONSENT_FINISHER_IDENTIFIER;
+    }
+}

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -123,6 +123,47 @@ prototypes:
                   9999:
                     identifier: removeButton
                     templateName: Inspector-RemoveElementEditor
+              # Allow to mark finishers shipped by EXT:form as consent dependent.
+              # Third-party finishers can opt in by adding the same editor.
+              #
+              # Only finishers that can be added in the form editor may receive
+              # this editor: for all other finishers, EXT:form validates every
+              # property against a hmac on save and rejects properties that were
+              # not part of the loaded form definition.
+              # @see FormDefinitionValidationService::validateAllPropertyCollectionElementValuesByHmac()
+              10:
+                editors:
+                  1500: &consentConditionEditor
+                    identifier: 'consentCondition'
+                    templateName: 'Inspector-SingleSelectEditor'
+                    label: 'formEditor.elements.Form.finisher.consentCondition.label'
+                    propertyPath: 'options.consentCondition'
+                    # Rendered by TYPO3 v14 only: the "Inspector-SingleSelectEditor"
+                    # template of TYPO3 v13 has no slot for it, neither for
+                    # "description" nor for "fieldExplanationText"
+                    description: 'formEditor.elements.Form.finisher.consentCondition.description'
+                    selectOptions:
+                      10:
+                        value: ''
+                        label: 'formEditor.elements.Form.finisher.consentCondition.option.none'
+                      20:
+                        value: 'needsApproval'
+                        label: 'formEditor.elements.Form.finisher.consentCondition.option.needsApproval'
+                      30:
+                        value: 'needsDismissal'
+                        label: 'formEditor.elements.Form.finisher.consentCondition.option.needsDismissal'
+              20:
+                editors:
+                  1500: *consentConditionEditor
+              30:
+                editors:
+                  1500: *consentConditionEditor
+              40:
+                editors:
+                  1500: *consentConditionEditor
+              50:
+                editors:
+                  1500: *consentConditionEditor
     formEngine:
       translationFiles:
         1632317570: 'EXT:form_consent/Resources/Private/Language/locallang_form.xlf'

--- a/Documentation/Usage/ConsentFinisher.rst
+++ b/Documentation/Usage/ConsentFinisher.rst
@@ -120,10 +120,10 @@ condition :php:`isConsentDismissed()` must then be used instead.
 Configuration in the form editor
 --------------------------------
 
-Form variants do not need to be maintained by hand. Each finisher that is
-shipped by EXT:form provides an additional :guilabel:`Execute finisher`
-option in the form editor, which is especially useful to store personal data
-only after the consent was actually approved:
+Form variants do not need to be maintained by hand. Every finisher that can be
+added in the form editor provides an additional :guilabel:`Execute finisher`
+option, which is especially useful to store personal data only after the
+consent was actually approved:
 
 *   :guilabel:`Immediately on form submit (default)` – the finisher is
     executed as usual, that is, when the form is submitted

--- a/Documentation/Usage/ConsentFinisher.rst
+++ b/Documentation/Usage/ConsentFinisher.rst
@@ -114,3 +114,90 @@ given and a redirect to the configured confirmation page would take place.
 
 The same behavior can be achieved in case the user revokes his consent. The
 condition :php:`isConsentDismissed()` must then be used instead.
+
+..  _post-consent-finisher-invocation-form-editor:
+
+Configuration in the form editor
+--------------------------------
+
+Form variants do not need to be maintained by hand. Each finisher that is
+shipped by EXT:form provides an additional :guilabel:`Execute finisher`
+option in the form editor, which is especially useful to store personal data
+only after the consent was actually approved:
+
+*   :guilabel:`Immediately on form submit (default)` – the finisher is
+    executed as usual, that is, when the form is submitted
+*   :guilabel:`Only after the consent was approved` – the finisher is
+    executed once the user approves the consent
+*   :guilabel:`Only after the consent was dismissed` – the finisher is
+    executed once the user dismisses the consent
+
+The selection is stored as :yaml:`consentCondition` option of the according
+finisher:
+
+..  code-block:: yaml
+    :emphasize-lines: 9
+
+    finishers:
+      -
+        identifier: Consent
+        options:
+          # ...
+      -
+        identifier: EmailToReceiver
+        options:
+          consentCondition: needsApproval
+          # ...
+
+During form runtime, the required form variants are derived from these
+options. The persisted form definition remains unchanged, so the form editor
+stays in full control of the configured finishers and their order.
+
+..  note::
+
+    The option only takes effect if the form uses the
+    :ref:`Consent finisher <consent-finisher>` as well. Otherwise, all
+    finishers are executed as usual.
+
+..  note::
+
+    The option is only available for finishers that can be added in the form
+    editor. Finishers such as :yaml:`SaveToDatabase`, :yaml:`Closure` and
+    :yaml:`FlashMessage` are excluded, because EXT:form rejects any property
+    that the form editor adds to them.
+
+    For those finishers, add the option to the :file:`.form.yaml` file
+    manually – it is evaluated the same way:
+
+    ..  code-block:: yaml
+
+        finishers:
+          -
+            identifier: Consent
+            options:
+              # ...
+          -
+            identifier: SaveToDatabase
+            options:
+              consentCondition: needsApproval
+              # ...
+
+    This is especially relevant to store personal data only after the consent
+    was actually approved.
+
+..  warning::
+
+    Do not combine both ways of configuration for the same condition within
+    one form. A form variant replaces the whole finisher list as soon as its
+    condition matches, and variants are applied in the order they are defined.
+    Since the derived variants are prepended, a manually configured variant
+    with the same condition is applied last and **discards** the finishers
+    that were marked in the form editor.
+
+    Use either the form editor or a manually configured variant per condition.
+
+..  tip::
+
+    Finishers provided by third-party extensions can opt in by adding the
+    same inspector editor to their form editor setup, see
+    :file:`Configuration/Yaml/FormSetup.yaml` of this extension.

--- a/Resources/Private/Language/locallang_form.xlf
+++ b/Resources/Private/Language/locallang_form.xlf
@@ -72,6 +72,22 @@
         <source>Consent</source>
       </trans-unit>
 
+      <trans-unit id="formEditor.elements.Form.finisher.consentCondition.label" resname="formEditor.elements.Form.finisher.consentCondition.label">
+        <source>Execute finisher</source>
+      </trans-unit>
+      <trans-unit id="formEditor.elements.Form.finisher.consentCondition.description" resname="formEditor.elements.Form.finisher.consentCondition.description">
+        <source>A condition only takes effect if this form also uses the Consent finisher. Without it, the finisher is always executed on form submit.</source>
+      </trans-unit>
+      <trans-unit id="formEditor.elements.Form.finisher.consentCondition.option.none" resname="formEditor.elements.Form.finisher.consentCondition.option.none">
+        <source>Immediately on form submit (default)</source>
+      </trans-unit>
+      <trans-unit id="formEditor.elements.Form.finisher.consentCondition.option.needsApproval" resname="formEditor.elements.Form.finisher.consentCondition.option.needsApproval">
+        <source>Only after the consent was approved</source>
+      </trans-unit>
+      <trans-unit id="formEditor.elements.Form.finisher.consentCondition.option.needsDismissal" resname="formEditor.elements.Form.finisher.consentCondition.option.needsDismissal">
+        <source>Only after the consent was dismissed</source>
+      </trans-unit>
+
       <trans-unit id="tt_content.finishersDefinition.Consent.label" resname="tt_content.finishersDefinition.Consent.label">
         <source>Consent</source>
       </trans-unit>

--- a/Tests/Functional/Configuration/FormSetupTest.php
+++ b/Tests/Functional/Configuration/FormSetupTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Configuration;
+
+use EliasHaeussler\Typo3FormConsent as Src;
+use EliasHaeussler\Typo3FormConsent\Tests;
+use PHPUnit\Framework;
+use TYPO3\CMS\Form;
+
+/**
+ * FormSetupTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class FormSetupTest extends Tests\Functional\ExtbaseRequestAwareFunctionalTestCase
+{
+    /**
+     * @var list<string>
+     */
+    private const EXPECTED_FINISHERS = [
+        'EmailToSender',
+        'EmailToReceiver',
+        'Redirect',
+        'DeleteUploads',
+        'Confirmation',
+    ];
+
+    /**
+     * Finishers that cannot be added in the form editor must not provide the
+     * editor: EXT:form rejects properties without hmac for those on save.
+     *
+     * @var list<string>
+     */
+    private const UNSUPPORTED_FINISHERS = [
+        'Closure',
+        'FlashMessage',
+        'SaveToDatabase',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'fluid_styled_content',
+        'form',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'form_consent',
+    ];
+
+    #[Framework\Attributes\Test]
+    public function consentConditionEditorIsAddedToFinishersCreatableInFormEditor(): void
+    {
+        $finishersWithEditor = [];
+
+        foreach ($this->getFinisherPropertyCollections() as $finisher) {
+            $editor = $this->findConsentConditionEditor($finisher['editors'] ?? []);
+
+            if ($editor === null) {
+                continue;
+            }
+
+            $finishersWithEditor[] = $finisher['identifier'] ?? '';
+
+            self::assertSame('options.consentCondition', $editor['propertyPath']);
+            self::assertSame(
+                ['', ...array_column(Src\Enums\ConsentCondition::cases(), 'value')],
+                array_column($editor['selectOptions'], 'value'),
+            );
+            // Editors must state that a condition requires the Consent finisher
+            self::assertNotSame('', $editor['description'] ?? '');
+        }
+
+        self::assertSame(self::EXPECTED_FINISHERS, $finishersWithEditor);
+    }
+
+    #[Framework\Attributes\Test]
+    public function consentConditionEditorIsNotAddedToUnsupportedFinishers(): void
+    {
+        foreach ($this->getFinisherPropertyCollections() as $finisher) {
+            $identifier = $finisher['identifier'] ?? '';
+
+            if (!in_array($identifier, ['Consent', ...self::UNSUPPORTED_FINISHERS], true)) {
+                continue;
+            }
+
+            self::assertNull(
+                $this->findConsentConditionEditor($finisher['editors'] ?? []),
+                sprintf('Finisher "%s" must not provide the consent condition editor.', $identifier),
+            );
+        }
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function getFinisherPropertyCollections(): array
+    {
+        $prototypeConfiguration = $this->get(Form\Domain\Configuration\ConfigurationService::class)
+            ->getPrototypeConfiguration('standard');
+
+        return array_values(
+            $prototypeConfiguration['formElementsDefinition']['Form']['formEditor']['propertyCollections']['finishers'],
+        );
+    }
+
+    /**
+     * @param array<mixed> $editors
+     * @return array<string, mixed>|null
+     */
+    private function findConsentConditionEditor(array $editors): ?array
+    {
+        foreach ($editors as $editor) {
+            if (is_array($editor) && ($editor['identifier'] ?? '') === Src\Enums\ConsentCondition::FINISHER_OPTION) {
+                return $editor;
+            }
+        }
+
+        return null;
+    }
+}

--- a/Tests/Functional/Event/Listener/ApplyFinisherVariantsListenerTest.php
+++ b/Tests/Functional/Event/Listener/ApplyFinisherVariantsListenerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Tests\Functional\Event\Listener;
+
+use EliasHaeussler\Typo3FormConsent as Src;
+use PHPUnit\Framework;
+use Psr\EventDispatcher;
+use TYPO3\CMS\Core;
+use TYPO3\CMS\Form\Mvc;
+use TYPO3\TestingFramework;
+
+/**
+ * ApplyFinisherVariantsListenerTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Event\Listener\ApplyFinisherVariantsListener::class)]
+final class ApplyFinisherVariantsListenerTest extends TestingFramework\Core\Functional\FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'form',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'form_consent',
+    ];
+
+    protected bool $initializeDatabase = false;
+
+    protected EventDispatcher\EventDispatcherInterface $eventDispatcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->eventDispatcher = $this->get(EventDispatcher\EventDispatcherInterface::class);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['TYPO3_REQUEST']);
+
+        parent::tearDown();
+    }
+
+    #[Framework\Attributes\Test]
+    public function listenerAppliesConsentVariantsOnFrontendRequests(): void
+    {
+        $this->initializeRequest(Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_FE);
+
+        $formDefinition = $this->dispatchEvent();
+
+        self::assertSame(
+            ['Consent'],
+            array_column($formDefinition['finishers'], 'identifier'),
+        );
+        self::assertSame(
+            Src\Enums\ConsentCondition::Approval->condition(),
+            $formDefinition['variants'][0]['condition'],
+        );
+        self::assertSame(
+            ['EmailToReceiver'],
+            array_column($formDefinition['variants'][0]['finishers'], 'identifier'),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function listenerDoesNotApplyConsentVariantsOnBackendRequests(): void
+    {
+        $this->initializeRequest(Core\Core\SystemEnvironmentBuilder::REQUESTTYPE_BE);
+
+        self::assertSame($this->formDefinition(), $this->dispatchEvent());
+    }
+
+    #[Framework\Attributes\Test]
+    public function listenerDoesNotApplyConsentVariantsIfRequestIsMissing(): void
+    {
+        unset($GLOBALS['TYPO3_REQUEST']);
+
+        self::assertSame($this->formDefinition(), $this->dispatchEvent());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function dispatchEvent(): array
+    {
+        $event = new Mvc\Persistence\Event\AfterFormDefinitionLoadedEvent(
+            $this->formDefinition(),
+            'contact',
+            'ext-form-load-contact',
+        );
+
+        $this->eventDispatcher->dispatch($event);
+
+        return $event->getFormDefinition();
+    }
+
+    private function initializeRequest(int $applicationType): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = (new Core\Http\ServerRequest('https://typo3-testing.local/'))
+            ->withAttribute('applicationType', $applicationType);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formDefinition(): array
+    {
+        return [
+            'identifier' => 'contact',
+            'type' => 'Form',
+            'finishers' => [
+                [
+                    'identifier' => 'Consent',
+                    'options' => [],
+                ],
+                [
+                    'identifier' => 'EmailToReceiver',
+                    'options' => [
+                        'consentCondition' => Src\Enums\ConsentCondition::Approval->value,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/Tests/Unit/Enums/ConsentConditionTest.php
+++ b/Tests/Unit/Enums/ConsentConditionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Enums;
+
+use EliasHaeussler\Typo3FormConsent as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * ConsentConditionTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Enums\ConsentCondition::class)]
+final class ConsentConditionTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    #[Framework\Attributes\Test]
+    public function conditionReturnsExpressionLanguageConditionOfConsentState(): void
+    {
+        self::assertSame('isConsentApproved()', Src\Enums\ConsentCondition::Approval->condition());
+        self::assertSame('isConsentDismissed()', Src\Enums\ConsentCondition::Dismissal->condition());
+    }
+
+    #[Framework\Attributes\Test]
+    public function variantIdentifierReturnsUniqueIdentifierForEachCase(): void
+    {
+        $identifiers = array_map(
+            static fn(Src\Enums\ConsentCondition $condition): string => $condition->variantIdentifier(),
+            Src\Enums\ConsentCondition::cases(),
+        );
+
+        self::assertSame($identifiers, array_unique($identifiers));
+        self::assertNotContains('', $identifiers);
+    }
+}

--- a/Tests/Unit/Form/ConsentVariantResolverTest.php
+++ b/Tests/Unit/Form/ConsentVariantResolverTest.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "form_consent".
+ *
+ * Copyright (C) 2021-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3FormConsent\Tests\Unit\Form;
+
+use EliasHaeussler\Typo3FormConsent as Src;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
+
+/**
+ * ConsentVariantResolverTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Form\ConsentVariantResolver::class)]
+final class ConsentVariantResolverTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    protected Src\Form\ConsentVariantResolver $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new Src\Form\ConsentVariantResolver();
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveReturnsFormDefinitionUnchangedIfFinishersAreMissing(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'type' => 'Form',
+        ];
+
+        self::assertSame($formDefinition, $this->subject->resolve($formDefinition));
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveReturnsFormDefinitionUnchangedIfConsentFinisherIsMissing(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+            ],
+        ];
+
+        self::assertSame($formDefinition, $this->subject->resolve($formDefinition));
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveReturnsFormDefinitionUnchangedIfNoFinisherIsMarkedAsConsentDependent(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('Confirmation'),
+            ],
+        ];
+
+        self::assertSame($formDefinition, $this->subject->resolve($formDefinition));
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveMovesConsentDependentFinishersToGeneratedVariant(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+                self::finisher('Confirmation'),
+            ],
+        ];
+
+        $expected = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('Confirmation'),
+            ],
+            'variants' => [
+                [
+                    'identifier' => Src\Enums\ConsentCondition::Approval->variantIdentifier(),
+                    'condition' => Src\Enums\ConsentCondition::Approval->condition(),
+                    'finishers' => [
+                        self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertSame($expected, $this->subject->resolve($formDefinition));
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveCreatesOneVariantPerConsentCondition(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('Redirect', Src\Enums\ConsentCondition::Dismissal->value),
+                self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+            ],
+        ];
+
+        $actual = $this->subject->resolve($formDefinition);
+
+        self::assertSame([self::finisher('Consent')], $actual['finishers']);
+        self::assertCount(2, $actual['variants']);
+        self::assertSame(
+            Src\Enums\ConsentCondition::Approval->condition(),
+            $actual['variants'][0]['condition'],
+        );
+        self::assertSame(
+            [self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value)],
+            $actual['variants'][0]['finishers'],
+        );
+        self::assertSame(
+            Src\Enums\ConsentCondition::Dismissal->condition(),
+            $actual['variants'][1]['condition'],
+        );
+        self::assertSame(
+            [self::finisher('Redirect', Src\Enums\ConsentCondition::Dismissal->value)],
+            $actual['variants'][1]['finishers'],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveKeepsManuallyConfiguredVariantsWithPrecedence(): void
+    {
+        $manualVariant = [
+            'identifier' => 'variant-1',
+            'condition' => 'isConsentApproved()',
+            'finishers' => [
+                self::finisher('Closure'),
+            ],
+        ];
+
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+            ],
+            'variants' => [
+                $manualVariant,
+            ],
+        ];
+
+        $actual = $this->subject->resolve($formDefinition);
+
+        self::assertCount(2, $actual['variants']);
+        self::assertSame(
+            Src\Enums\ConsentCondition::Approval->variantIdentifier(),
+            $actual['variants'][0]['identifier'],
+        );
+        self::assertSame($manualVariant, $actual['variants'][1]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveIgnoresUnknownConsentConditions(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('EmailToReceiver', 'needsSomethingElse'),
+            ],
+        ];
+
+        self::assertSame($formDefinition, $this->subject->resolve($formDefinition));
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveIgnoresConsentConditionOnConsentFinisher(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent', Src\Enums\ConsentCondition::Approval->value),
+                self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+            ],
+        ];
+
+        $actual = $this->subject->resolve($formDefinition);
+
+        self::assertSame(
+            [self::finisher('Consent', Src\Enums\ConsentCondition::Approval->value)],
+            $actual['finishers'],
+        );
+        self::assertSame(
+            [self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value)],
+            $actual['variants'][0]['finishers'],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveIgnoresMalformedVariantsConfiguration(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+            ],
+            'variants' => 'not-a-list',
+        ];
+
+        $actual = $this->subject->resolve($formDefinition);
+
+        self::assertCount(1, $actual['variants']);
+        self::assertSame(
+            Src\Enums\ConsentCondition::Approval->variantIdentifier(),
+            $actual['variants'][0]['identifier'],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveIsIdempotent(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+            ],
+        ];
+
+        $resolvedOnce = $this->subject->resolve($formDefinition);
+
+        self::assertSame($resolvedOnce, $this->subject->resolve($resolvedOnce));
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolvePreservesConfiguredFinisherOrder(): void
+    {
+        $formDefinition = [
+            'identifier' => 'contact',
+            'finishers' => [
+                self::finisher('Consent'),
+                self::finisher('EmailToReceiver', Src\Enums\ConsentCondition::Approval->value),
+                self::finisher('DeleteUploads'),
+                self::finisher('Redirect', Src\Enums\ConsentCondition::Approval->value),
+            ],
+        ];
+
+        $actual = $this->subject->resolve($formDefinition);
+
+        self::assertSame(
+            ['Consent', 'DeleteUploads'],
+            array_column($actual['finishers'], 'identifier'),
+        );
+        self::assertSame(
+            ['EmailToReceiver', 'Redirect'],
+            array_column($actual['variants'][0]['finishers'], 'identifier'),
+        );
+    }
+
+    /**
+     * @return array{identifier: string, options: array<string, mixed>}
+     */
+    private static function finisher(string $identifier, ?string $consentCondition = null): array
+    {
+        $options = ['subject' => 'dummy'];
+
+        if ($consentCondition !== null) {
+            $options['consentCondition'] = $consentCondition;
+        }
+
+        return [
+            'identifier' => $identifier,
+            'options' => $options,
+        ];
+    }
+}


### PR DESCRIPTION
Closes #353. Alternative implementation to #354, thanks to @alexanderkuenzl for raising the feature and for the initial draft, which this builds on conceptually.

## Why

Invoking finishers after approval or dismissal currently requires a form variant at the root level of the `.form.yaml`. In effect, only developers can decide which finisher runs after consent was given, every change to "send the notification only once the user confirmed" needs a file change and a deployment.

In a real-world integration this turned out to be more than an inconvenience. The setup that editors *can* reach in the form editor, add the Consent finisher, keep the existing "send e-mail to us" finisher, looks complete, but is wrong: the notification is sent immediately on submit, before the user confirmed anything. Nothing in the backend indicates that a variant is missing. During acceptance testing this was reported as a bug ("confirmation mail is sent too early"), when in fact it was a configuration that editors had no way to get right. The failure mode is privacy-relevant, because personal data is forwarded before consent exists.

This matters more than it used to: plain double opt-in has become unreliable where mail security scanners follow links automatically, so the confirmation needs an extra explicit click (`requireApproveVerification`). That makes the correct post-consent finisher configuration essential, and it is exactly the part editors cannot currently configure themselves.

## What it does

Every finisher that EXT:form offers in the form editor gets an additional `Execute finisher` select:

- `Immediately on form submit (default)`
- `Only after the consent was approved`
- `Only after the consent was dismissed`

Editors no longer need to hand-write form variants to invoke finishers after approval or dismissal.

<img width="349" height="459" alt="Bildschirmfoto 2026-08-03 um 15 43 30" src="https://github.com/user-attachments/assets/aa5cb9ff-6150-4e53-a567-48f1b67c0fc1" />

## How it works

The selection is stored as a regular finisher option (`options.consentCondition`), the form editor persists it natively, so no save hook and no response manipulation is required.

The required form variants are derived at **form runtime only**: a listener on `AfterFormDefinitionLoadedEvent` moves the marked finishers into a generated root-level variant (`isConsentApproved()` / `isConsentDismissed()`) and removes them from the default finisher list, since a matching variant replaces the whole finisher list.

```yaml
# persisted (unchanged by the extension)
finishers:
  - identifier: Consent
    options: { ... }
  - identifier: EmailToReceiver
    options:
      consentCondition: needsApproval

# form runtime (derived, not persisted)
finishers:
  - identifier: Consent
variants:
  - identifier: form-consent-approval-variant
    condition: isConsentApproved()
    finishers:
      - identifier: EmailToReceiver
```

Consequences of deriving instead of persisting:

- The form editor and the backend see the definition unchanged, no round-trip loss, no finisher reordering, no data migration.
- `InvokeFinishersListener::areFinisherVariantsConfigured()` keeps working unchanged, because it reads through `FormPersistenceManager::load()`.
- Works identically on TYPO3 v13 and v14, `AfterFormDefinitionLoadedEvent` exists in both, whereas the `beforeFormSave` / `beforeFormCreate` hooks were removed in v14.
- Manually configured variants are kept and take precedence, since generated variants are prepended.

## Behaviour details

- The option only takes effect if the form also uses the `Consent` finisher, otherwise the definition is returned unchanged.
- The `Consent` finisher itself never offers the option and is never moved into a variant.
- The transformation is idempotent (the event is dispatched on every `load()`, including runtime cache hits) and only applied to frontend requests.
- Unknown option values are ignored.
- Third-party finishers can opt in by adding the same inspector editor; the editor definition is a single YAML anchor.
- The editor is deliberately limited to the five finishers that can be *added* in the form editor. For all others (`SaveToDatabase`, `Closure`, `FlashMessage`), `FormDefinitionValidationService` takes the hmac-only branch on save and rejects any property the form editor added, so offering the select there would make every form containing such a finisher unsavable. The option still works for them when written into the `.form.yaml` by hand, this is covered by a regression test and documented.

## Trade-offs and limitations

Please review these deliberately, they are consequences of deriving instead of persisting, and a maintainer may weigh them differently.

**Derived variants are not inspectable.** With the hook-based approach in #354, the resulting variants end up in the `.form.yaml` and are self-documenting. Here they only exist at runtime, so debugging an unexpected form requires knowing that this extension derives them. This is the price for not mutating persisted data, and it is only mitigated by documentation.

**Do not combine both mechanisms for the same condition.** Variants are applied in definition order and each matching variant replaces the entire finisher list (`RenderableVariant::apply()` → `setOptions(…, resetFinishers: true)`). Generated variants are prepended so manual ones keep precedence, which means a manually configured variant with the same condition silently discards the finishers marked in the form editor. Verified against a real `FormDefinition`; documented with a warning. Making this a union instead would mean rewriting hand-written variants
at runtime, which felt worse than rejecting the combination.

**The `Consent` finisher identifier is hardcoded.** If somebody registers `ConsentFinisher` under a different identifier, the feature is silently inert. Resolving it via `finishersDefinition[…].implementationClassName` would add a configuration dependency to the otherwise dependency-free resolver. Happy to change this if you prefer.

**Limited backend feedback when the condition cannot apply.** The inspector editor is static per finisher type and cannot know whether the form contains a Consent finisher, so the select is shown either way and a condition without a Consent finisher simply has no effect (rather than silently dropping the finisher, which would be data loss). A `description` on the select states the requirement, note that this renders on TYPO3 v14 only, because the `Inspector-SingleSelectEditor` template of v13 has no slot for it (neither `description` nor the deprecated `fieldExplanationText`). A save-time validation would need a hook EXT:form does not offer.

## Files

| File | Purpose |
|---|---|
| `Classes/Enums/ConsentCondition.php` | Condition cases, expression language conditions, variant identifiers |
| `Classes/Form/ConsentVariantResolver.php` | Derives variants from finisher options (pure, dependency-free) |
| `Classes/Event/Listener/ApplyFinisherVariantsListener.php` | Applies the resolver on frontend requests |
| `Configuration/Yaml/FormSetup.yaml` | Inspector editor for the five editor-addable core finishers |
| `Resources/Private/Language/locallang_form.xlf` | Labels (source language only) |
| `Documentation/Usage/ConsentFinisher.rst` | New section “Configuration in the form editor” |

## Test plan

- [x] `composer test:unit` 78 tests, incl. 11 resolver cases (guards, both conditions, manual variants, malformed configuration, idempotency, finisher order)
- [x] `composer test:functional`  57 tests, incl. 5 new cases covering event listener registration, the frontend/backend/CLI guard and the merged form editor setup (the latter also guards against renumbered core finishers)
- [x] `composer check`  dependency analyser, Rector, PHPStan level 8, CS-Fixer, composer normalize, editorconfig, TypoScript lint
- [x] Manual verification on TYPO3 v14.3.5 and v13.4.33 (PHP 8.5): `EmailToReceiver` marked as `Only after the consent was approved` in the form editor, the admin mail arrives only after the approval link was used, not on form submit
- [x] Manual verification of the dismissal path (`Only after the consent was dismissed`)
- [x] Automated suite run against both major versions: 78 unit and 57 functional tests green on v13.4.33 and v14.3.5. This change adds no deprecation of its own, the four remaining `fieldExplanationText` deprecations on v14 all belong to the pre-existing Consent finisher editors
- [x] The `description` hint is rendered below the select in the TYPO3 v14 form editor (v13 has no template slot for it, see limitations)
- [x] Round trip verified against the editor-written `.form.yaml`: the option is stored in the finisher options, no variant block is persisted, and the derived runtime definition moves only the marked finisher into the variant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consent-based finisher execution options: immediate, after approval, or after dismissal.
  * Added form editor controls for configuring consent conditions on supported finishers.
  * Automatically applies consent-specific finisher variants in frontend forms.
  * Preserves manually configured variants and existing form definitions.

* **Documentation**
  * Added configuration guidance, compatibility notes, and localized descriptions for consent conditions.

* **Tests**
  * Added coverage for editor integration, variant generation, request handling, and consent-condition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->